### PR TITLE
feat: add variant field to agent config schema

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,6 +5,7 @@ import { AGENTS } from "@/agents";
 export const AgentOverrideSchema = v.partial(
   v.object({
     model: v.string(),
+    variant: v.string(),
     temperature: v.pipe(v.number(), v.minValue(0), v.maxValue(2)),
     maxSteps: v.pipe(v.number(), v.integer(), v.minValue(1)),
   }),

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -122,6 +122,41 @@ describe("OcttoConfigSchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe("agents with variant", () => {
+    it("should accept agent config with variant", () => {
+      const result = v.safeParse(OcttoConfigSchema, {
+        agents: {
+          octto: { model: "openai/gpt-5.2", variant: "high" },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.agents?.octto?.variant).toBe("high");
+      }
+    });
+
+    it("should accept agent config without variant", () => {
+      const result = v.safeParse(OcttoConfigSchema, {
+        agents: {
+          octto: { model: "openai/gpt-5.2" },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.agents?.octto?.variant).toBeUndefined();
+      }
+    });
+
+    it("should reject non-string variant", () => {
+      const result = v.safeParse(OcttoConfigSchema, {
+        agents: {
+          octto: { variant: 123 },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe("FragmentsSchema", () => {


### PR DESCRIPTION
## Summary
- Adds an optional `variant` string field to `AgentOverrideSchema` in `src/config/schema.ts`
- This allows users to specify model variants (e.g. `"high"`, `"thinking"`, `"max"`) in their `octto.json` agent configuration
- The variant value passes through validation and gets merged into opencode's `AgentConfig` (which accepts it via its `[key: string]: unknown` index signature)

## Changes
- `src/config/schema.ts`: Added `variant: v.string()` to the `AgentOverrideSchema` object (inside `v.partial()`, so it's optional)
- `tests/config/schema.test.ts`: Added 3 tests covering variant acceptance, optionality, and type rejection

## Example Config
```json
{
  "agents": {
    "octto": {
      "model": "github-copilot/gpt-5.2",
      "variant": "high"
    }
  }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional variant field to the agent config schema so users can specify model variants (e.g., "high", "thinking"). The field is validated as a string and passed through to AgentConfig; tests cover acceptance, optionality, and type rejection.

<sup>Written for commit 2442561b0e9881969b1ee5d86f07a5dcb894f4e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

