### PR TITLE
Fix agent configuration merge order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const Octto: Plugin = async ({ client, directory }) => {
 
     config: async (config) => {
       // Apply agent overrides from custom config (fragments already injected at plugin load)
-      config.agent = { ...config.agent, ...customConfig.agents };
+      config.agent = { ...customConfig.agents, ...config.agent };
     },
 
     event: async ({ event }) => {


### PR DESCRIPTION
At this case we will be able to override configuration from opencode.json config file. At the case, if we want to choose another model, for example, not codex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix agent configuration merge order so values in opencode.json take precedence over defaults. This lets users override agent options, like choosing a non-codex model.

<sup>Written for commit 90106c134595602d3f2dafd58bcb5c4f69eeee36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

