### PR TITLE
feat: add top-level model key to override all agents at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ Optional `~/.config/opencode/octto.json`:
 
 ```json
 {
+  "model": "anthropic/claude-sonnet-4",
   "port": 3000,
   "agents": {
-    "probe": { "model": "anthropic/claude-sonnet-4" }
+    "probe": { "model": "openai/gpt-4o" }
   }
 }
 ```
@@ -115,9 +116,12 @@ Optional `~/.config/opencode/octto.json`:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `model` | string | - | Override the model for **all** agents at once |
 | `port` | number | `0` (random) | Fixed port for the browser UI server |
-| `agents` | object | - | Override agent models/settings |
+| `agents` | object | - | Per-agent overrides (model, temperature, etc.) |
 | `fragments` | object | - | Custom instructions injected into agent prompts |
+
+> **Precedence**: per-agent `agents.<name>.model` > top-level `model` > built-in default
 
 ### Fragments
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -53,39 +53,46 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function salvageValidAgents(parsed: Record<string, unknown>): OcttoConfig | null {
-  if (!("agents" in parsed) || !isRecord(parsed.agents)) {
-    console.warn("[octto] No valid agents found in config, using defaults");
-    return null;
+  const result: OcttoConfig = {};
+
+  // Salvage top-level model if it's a valid string
+  if ("model" in parsed && typeof parsed.model === "string" && parsed.model.length > 0) {
+    result.model = parsed.model;
   }
 
-  const rawAgents = parsed.agents;
+  if ("agents" in parsed && isRecord(parsed.agents)) {
+    const rawAgents = parsed.agents;
+    const validAgents: OcttoConfig["agents"] = {};
+    let hasValidAgent = false;
 
-  const validAgents: OcttoConfig["agents"] = {};
-  let hasValidAgent = false;
+    for (const [name, override] of Object.entries(rawAgents)) {
+      if (!isAgentName(name)) {
+        console.warn(`[octto] Unknown agent "${name}" - valid names: ${VALID_AGENT_NAMES.join(", ")}`);
+        continue;
+      }
 
-  for (const [name, override] of Object.entries(rawAgents)) {
-    if (!isAgentName(name)) {
-      console.warn(`[octto] Unknown agent "${name}" - valid names: ${VALID_AGENT_NAMES.join(", ")}`);
-      continue;
+      const agentResult = v.safeParse(AgentOverrideSchema, override);
+      if (agentResult.success) {
+        validAgents[name] = agentResult.output;
+        hasValidAgent = true;
+      } else {
+        console.warn(`[octto] Invalid config for agent "${name}":`);
+        console.warn(formatValidationErrors(agentResult.issues));
+      }
     }
 
-    const agentResult = v.safeParse(AgentOverrideSchema, override);
-    if (agentResult.success) {
-      validAgents[name] = agentResult.output;
-      hasValidAgent = true;
-    } else {
-      console.warn(`[octto] Invalid config for agent "${name}":`);
-      console.warn(formatValidationErrors(agentResult.issues));
+    if (hasValidAgent) {
+      result.agents = validAgents;
     }
   }
 
-  if (!hasValidAgent) {
-    console.warn("[octto] No valid agent overrides found, using defaults");
-    return null;
+  if (result.model || result.agents) {
+    console.warn("[octto] Partial config loaded - some overrides applied despite errors");
+    return result;
   }
 
-  console.warn("[octto] Partial config loaded - some overrides applied despite errors");
-  return { agents: validAgents };
+  console.warn("[octto] No valid overrides found in config, using defaults");
+  return null;
 }
 
 async function load(configDir?: string): Promise<OcttoConfig | null> {
@@ -120,6 +127,11 @@ async function load(configDir?: string): Promise<OcttoConfig | null> {
 /**
  * Load user configuration and merge with plugin agents.
  * Returns merged agent configs with user overrides applied, and resolved port.
+ *
+ * Merge order (later wins):
+ *   1. Built-in agent defaults
+ *   2. Top-level `model` (applied to every agent)
+ *   3. Per-agent `agents.<name>` overrides
  */
 export async function loadCustomConfig(
   agents: Record<AgentName, AgentConfig>,
@@ -128,9 +140,18 @@ export async function loadCustomConfig(
   const config = await load(configDir);
 
   const mergedAgents = { ...agents };
+
+  // Apply top-level model to all agents first
+  if (config?.model) {
+    for (const name of Object.values(AGENTS)) {
+      mergedAgents[name] = { ...mergedAgents[name], model: config.model };
+    }
+  }
+
+  // Then apply per-agent overrides (these take precedence)
   for (const [name, override] of Object.entries(config?.agents ?? {})) {
     if (!isAgentName(name)) continue;
-    mergedAgents[name] = { ...agents[name], ...override };
+    mergedAgents[name] = { ...mergedAgents[name], ...override };
   }
 
   return {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -52,43 +52,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function salvageValidAgents(parsed: Record<string, unknown>): OcttoConfig | null {
-  const result: OcttoConfig = {};
-
-  // Salvage top-level model if it's a valid string
+function salvageModel(parsed: Record<string, unknown>): string | undefined {
   if ("model" in parsed && typeof parsed.model === "string" && parsed.model.length > 0) {
-    result.model = parsed.model;
+    return parsed.model;
+  }
+  return undefined;
+}
+
+function salvageAgentOverrides(parsed: Record<string, unknown>): OcttoConfig["agents"] | undefined {
+  if (!("agents" in parsed) || !isRecord(parsed.agents)) {
+    return undefined;
   }
 
-  if ("agents" in parsed && isRecord(parsed.agents)) {
-    const rawAgents = parsed.agents;
-    const validAgents: OcttoConfig["agents"] = {};
-    let hasValidAgent = false;
+  const validAgents: OcttoConfig["agents"] = {};
+  let hasValidAgent = false;
 
-    for (const [name, override] of Object.entries(rawAgents)) {
-      if (!isAgentName(name)) {
-        console.warn(`[octto] Unknown agent "${name}" - valid names: ${VALID_AGENT_NAMES.join(", ")}`);
-        continue;
-      }
-
-      const agentResult = v.safeParse(AgentOverrideSchema, override);
-      if (agentResult.success) {
-        validAgents[name] = agentResult.output;
-        hasValidAgent = true;
-      } else {
-        console.warn(`[octto] Invalid config for agent "${name}":`);
-        console.warn(formatValidationErrors(agentResult.issues));
-      }
+  for (const [name, override] of Object.entries(parsed.agents)) {
+    if (!isAgentName(name)) {
+      console.warn(`[octto] Unknown agent "${name}" - valid names: ${VALID_AGENT_NAMES.join(", ")}`);
+      continue;
     }
 
-    if (hasValidAgent) {
-      result.agents = validAgents;
+    const agentResult = v.safeParse(AgentOverrideSchema, override);
+    if (agentResult.success) {
+      validAgents[name] = agentResult.output;
+      hasValidAgent = true;
+    } else {
+      console.warn(`[octto] Invalid config for agent "${name}":`);
+      console.warn(formatValidationErrors(agentResult.issues));
     }
   }
 
-  if (result.model || result.agents) {
+  return hasValidAgent ? validAgents : undefined;
+}
+
+function salvageValidConfig(parsed: Record<string, unknown>): OcttoConfig | null {
+  const model = salvageModel(parsed);
+  const agents = salvageAgentOverrides(parsed);
+
+  if (model || agents) {
     console.warn("[octto] Partial config loaded - some overrides applied despite errors");
-    return result;
+    return { ...(model ? { model } : {}), ...(agents ? { agents } : {}) };
   }
 
   console.warn("[octto] No valid overrides found in config, using defaults");
@@ -121,7 +125,7 @@ async function load(configDir?: string): Promise<OcttoConfig | null> {
     return null;
   }
 
-  return salvageValidAgents(parsed);
+  return salvageValidConfig(parsed);
 }
 
 /**

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -18,6 +18,7 @@ export const PortSchema = v.pipe(v.number(), v.integer(), v.minValue(0), v.maxVa
 export const FragmentsSchema = v.optional(v.record(v.picklist(Object.values(AGENTS)), v.array(v.string())));
 
 export const OcttoConfigSchema = v.object({
+  model: v.optional(v.string()),
   agents: v.optional(v.record(v.picklist(Object.values(AGENTS)), AgentOverrideSchema)),
   port: v.optional(PortSchema),
   fragments: FragmentsSchema,

--- a/tests/config/loader-integration.test.ts
+++ b/tests/config/loader-integration.test.ts
@@ -95,4 +95,72 @@ describe("loadCustomConfig", () => {
 
     expect(result.fragments).toEqual({ octto: ["Be concise"] });
   });
+
+  it("should apply top-level model to all agents", async () => {
+    writeFileSync(
+      join(configDir, "octto.json"),
+      JSON.stringify({
+        model: "anthropic/claude-sonnet-4",
+      }),
+    );
+
+    const result = await loadCustomConfig(stubAgents, configDir);
+
+    expect(result.agents.octto.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.bootstrapper.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.probe.model).toBe("anthropic/claude-sonnet-4");
+    // Non-model fields should remain unchanged
+    expect(result.agents.octto.prompt).toBe("octto prompt");
+  });
+
+  it("should let per-agent model override top-level model", async () => {
+    writeFileSync(
+      join(configDir, "octto.json"),
+      JSON.stringify({
+        model: "anthropic/claude-sonnet-4",
+        agents: {
+          probe: { model: "openai/gpt-4o" },
+        },
+      }),
+    );
+
+    const result = await loadCustomConfig(stubAgents, configDir);
+
+    expect(result.agents.octto.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.bootstrapper.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.probe.model).toBe("openai/gpt-4o");
+  });
+
+  it("should use defaults when top-level model is not set", async () => {
+    writeFileSync(
+      join(configDir, "octto.json"),
+      JSON.stringify({}),
+    );
+
+    const result = await loadCustomConfig(stubAgents, configDir);
+
+    expect(result.agents.octto.model).toBe("test-model");
+    expect(result.agents.bootstrapper.model).toBe("test-model");
+    expect(result.agents.probe.model).toBe("test-model");
+  });
+
+  it("should salvage top-level model from partially invalid config", async () => {
+    writeFileSync(
+      join(configDir, "octto.json"),
+      JSON.stringify({
+        model: "anthropic/claude-sonnet-4",
+        agents: {
+          octto: { temperature: 999 },
+        },
+      }),
+    );
+
+    const result = await loadCustomConfig(stubAgents, configDir);
+
+    // Top-level model should still apply even when agent config is invalid
+    expect(result.agents.octto.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.bootstrapper.model).toBe("anthropic/claude-sonnet-4");
+    expect(result.agents.probe.model).toBe("anthropic/claude-sonnet-4");
+    expect(warnSpy).toHaveBeenCalled();
+  });
 });

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -6,6 +6,43 @@ import * as v from "valibot";
 import { FragmentsSchema, OcttoConfigSchema } from "../../src/config/schema";
 
 describe("OcttoConfigSchema", () => {
+  describe("top-level model field", () => {
+    it("should accept a top-level model string", () => {
+      const result = v.safeParse(OcttoConfigSchema, { model: "anthropic/claude-sonnet-4" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.model).toBe("anthropic/claude-sonnet-4");
+      }
+    });
+
+    it("should allow config without top-level model (optional)", () => {
+      const result = v.safeParse(OcttoConfigSchema, {});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.model).toBeUndefined();
+      }
+    });
+
+    it("should reject non-string model", () => {
+      const result = v.safeParse(OcttoConfigSchema, { model: 123 });
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept model alongside agents overrides", () => {
+      const result = v.safeParse(OcttoConfigSchema, {
+        model: "anthropic/claude-sonnet-4",
+        agents: {
+          probe: { model: "openai/gpt-4o" },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.output.model).toBe("anthropic/claude-sonnet-4");
+        expect(result.output.agents?.probe?.model).toBe("openai/gpt-4o");
+      }
+    });
+  });
+
   describe("port field", () => {
     it("should accept valid port number", () => {
       const result = v.safeParse(OcttoConfigSchema, { port: 3000 });


### PR DESCRIPTION
## Summary

Closes #16. Closes #8. Adds a top-level `model` key to `octto.json` that applies to every agent, so users with GitHub Copilot (or any non-OpenAI provider) can set a single model string instead of repeating it three times under `agents.*.model`.

## Changes

- **`src/config/schema.ts`**: Add optional top-level `model` to `OcttoConfigSchema`
- **`src/config/loader.ts`**: Apply top-level model to all agents before per-agent overrides; extract salvage helpers to satisfy eslint complexity rules
- **`README.md`**: Document the new `model` option and precedence rules
- **Tests**: 5 new schema tests + 4 loader integration tests covering merge precedence, salvage behavior, and defaults

## Merge Precedence

```
per-agent override  >  top-level model  >  built-in default
```

## Example `octto.json`

```json
{
  "model": "github-copilot/claude-opus-4.6",
  "agents": {
    "probe": {
      "model": "github-copilot/claude-sonnet-4",
      "temperature": 0.3
    }
  }
}
```

All agents use `claude-opus-4.6` except `probe`, which uses its per-agent override.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top-level `model` key to `octto.json` to set the model for all agents at once. Per-agent overrides still win, making it simpler to use providers like GitHub Copilot.

- New Features
  - Optional top-level `model` applied to every agent.
  - Merge order: per-agent `agents.<name>.model` > top-level `model` > built-in default.
  - Loader applies the top-level model before per-agent overrides and salvages it from partial configs.
  - Updated README and added schema + loader tests.

<sup>Written for commit 624b7569ed6cfdb2fc18fe384abe1b8bea61ee1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

