### PR TITLE
chore: add nix dev shell with bun, node, biome, lefthook

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761597516,
+        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "revCount": 811874,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "octto — interactive brainstorming plugin for OpenCode";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      systems,
+      ...
+    }:
+    let
+      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # Runtime & package manager
+            bun
+
+            # Node.js — needed by tsc (via typescript devDep) and @opencode-ai/plugin
+            nodejs_22
+
+            # Build / lint (also installed via bun but handy on PATH for editors)
+            biome
+            lefthook
+
+            # Nix tooling
+            nil # nix LSP
+            nixfmt-rfc-style
+          ];
+
+          shellHook = ''
+            echo "octto dev shell"
+            echo "  bun  $(bun --version)"
+            echo "  node $(node --version)"
+
+            # Install deps if node_modules is missing or stale
+            if [ ! -d node_modules ] || [ package.json -nt node_modules/.package-lock.json 2>/dev/null ]; then
+              echo "→ running bun install..."
+              bun install --frozen-lockfile 2>/dev/null || bun install
+            fi
+
+            # Make devDep binaries available (tsc, eslint, etc.)
+            export PATH="$PWD/node_modules/.bin:$PATH"
+          '';
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Summary

Adds a Nix flake-based development shell so contributors using Nix/NixOS can get a reproducible dev environment with a single command.

## Changes

- **`flake.nix`**: Dev shell providing bun, nodejs, biome, and lefthook
- **`flake.lock`**: Pinned nixpkgs for reproducibility
- **`.envrc`**: `use flake` for automatic direnv activation

## Usage

```bash
# With nix
nix develop

# Or with direnv (auto-activates on cd)
direnv allow
```

Provides: `bun`, `node`, `biome`, `lefthook` — everything needed to build, test, lint, and run git hooks.

No impact on existing workflows — these files are only consumed by Nix tooling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Nix flake dev shell for a fast, reproducible setup with `bun`, `node`, `biome`, and `lefthook`. This is optional and does not change existing workflows.

- **New Features**
  - `flake.nix`: Dev shell with `bun`, `nodejs_22`, `biome`, `lefthook`, plus `nil` and `nixfmt-rfc-style`.
  - `flake.lock`: Pins `nixpkgs` for reproducibility.
  - `.envrc`: Uses `direnv` (`use flake`) for auto-activation.
  - Shell hook prints versions, runs `bun install` if needed, and adds `node_modules/.bin` to `PATH`. Usage: `nix develop` or `direnv allow`.

<sup>Written for commit 1507b9ea47a1a351b90ada8f9af05fe7bed3b274. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

