### PR TITLE
fix(tools): relax questionsSchema to allow all config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An interactive browser UI for AI brainstorming. Stop typing in terminals. Start clicking in browsers.
 
+> **About this Fork:** This fork fixes the `start_session` tool schema. The original version only defined `question` and `context` in the config object, causing the AI to omit important properties like `options` (needed for `pick_one`, `pick_many`, etc.). Now all config properties are supported. [See changes →](https://github.com/MoriNo23/octto/pull/1)
+
 
 
 https://github.com/user-attachments/assets/9ba8868d-16f3-4451-9b73-6b7e1fc54655

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -9,6 +9,7 @@ export type {
   BaseConfig,
   ConfirmAnswer,
   EmojiReactAnswer,
+  InitialQuestion,
   PickManyAnswer,
   PickOneAnswer,
   QuestionAnswers,

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -1,6 +1,6 @@
 import { tool } from "@opencode-ai/plugin/tool";
 
-import type { SessionStore } from "@/session";
+import type { InitialQuestion, SessionStore } from "@/session";
 
 import type { OcttoTool, OcttoTools } from "./types";
 
@@ -46,14 +46,32 @@ const questionsSchema = tool.schema
   .array(
     tool.schema.object({
       type: tool.schema
-        .enum(["pick_one", "pick_many", "confirm", "ask_text", "show_options", "review_section", "thumbs", "slider"])
+        .enum([
+          "pick_one",
+          "pick_many",
+          "confirm",
+          "ask_text",
+          "show_options",
+          "review_section",
+          "thumbs",
+          "slider",
+          "rank",
+          "rate",
+          "ask_image",
+          "ask_file",
+          "ask_code",
+          "show_diff",
+          "show_plan",
+          "emoji_react",
+        ])
         .describe("Question type"),
-      config: tool.schema
-        .looseObject({
-          question: tool.schema.string().optional(),
-          context: tool.schema.string().optional(),
-        })
-        .describe("Question config (varies by type)"),
+      config: tool.schema.unknown().describe(`Question config (varies by type). Common properties:
+- question: string - The question text
+- context: string - Additional context
+- options: Array<{id: string, label: string, description?: string}> - For pick_one, pick_many, rank, rate
+- recommended: string - Recommended option id
+- min/max: number - For slider, rate
+- allowOther: boolean - Allow custom input for pick_one/pick_many`),
     }),
   )
   .describe("REQUIRED: Initial questions to display when browser opens. Must have at least 1.");
@@ -73,7 +91,8 @@ REQUIRED: You MUST provide at least 1 question. Will fail without questions.`,
       }
 
       try {
-        const session = await sessions.startSession({ title: args.title, questions: args.questions });
+        const initialQuestions = args.questions as unknown as InitialQuestion[];
+        const session = await sessions.startSession({ title: args.title, questions: initialQuestions });
         return formatSessionStarted(session);
       } catch (error: unknown) {
         return `Failed to start session: ${error instanceof Error ? error.message : String(error)}`;


### PR DESCRIPTION
## Description
Fixes issue where the AI was omitting the `options` property (and other important properties like `min`, `max`, `recommended`, etc) when calling `start_session`.

The original `questionsSchema` explicitly defined only `question` and `context` inside the config object using `.looseObject()`. However, when LLMs read the tool schema documentation, they assume those are the *only* properties allowed and strip away others like `options`, leading to blank select lists in the UI.

Fixes #6

## Changes made
- Changed `config` schema to `.unknown()`
- Added detailed string description to `config` listing all the common properties so the LLM knows what to pass
- Added missing question types (`rank`, `rate`, `ask_image`, `ask_file`, `ask_code`, `show_diff`, `show_plan`, `emoji_react`) to the tool enum

## Testing
- TypeScript compiles without errors
- Build completes successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed the `start_session` tool schema so `config` accepts all properties, fixing dropped fields like `options`, `min/max`, and `recommended` that caused blank selects in the UI. Also added missing question types and exported `InitialQuestion`.

- **Bug Fixes**
  - Changed `config` to `.unknown()` and documented common fields to prevent stripping important properties.
  - Passed `args.questions` as `InitialQuestion[]` when starting a session to align types.

- **New Features**
  - Added question types: `rank`, `rate`, `ask_image`, `ask_file`, `ask_code`, `show_diff`, `show_plan`, `emoji_react`.
  - Exported `InitialQuestion` and updated README with a short note about the schema fix.

<sup>Written for commit 4f734757796ab0656416e9e29df7364fc34538c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

