### PR TITLE
ci: regenerate bun.lock on dependabot branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # TypeScript 7's native API breaks ts-api-utils, which typescript-eslint
+      # and eslint-plugin-sonarjs depend on, so ESLint crashes on load.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   check:
+    # Dependabot branches run the gate in dependabot-lockfile.yml, after the
+    # lockfile is regenerated. Running it here too would always fail on the
+    # frozen lockfile.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,45 @@
+name: Dependabot Lockfile
+
+# Dependabot's npm ecosystem updates package.json but cannot write bun.lock,
+# which makes `bun install --frozen-lockfile` in the quality gate reject the
+# mismatch. Regenerate the lockfile here, then run the gate in the same job:
+# a GITHUB_TOKEN push does not retrigger workflows, so the pushed commit would
+# otherwise never be verified.
+
+on:
+  push:
+    branches: ["dependabot/**"]
+
+permissions:
+  contents: write
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Resolve dependencies
+        run: bun install
+
+      - name: Sync lockfile
+        run: |
+          if git diff --quiet bun.lock; then
+            echo "bun.lock already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(deps): sync bun.lock" bun.lock
+          git push
+
+      - name: Quality gate
+        run: bun run check
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
Dependabot's npm ecosystem updates `package.json` but cannot write `bun.lock`, so `bun install --frozen-lockfile` in the quality gate rejected every npm bump with `error: lockfile had changes, but lockfile is frozen`. That is what blocked #42, #43 and #44.

## Changes

- **`dependabot-lockfile.yml`**: on push to `dependabot/**`, resolve dependencies, commit `bun.lock` if it changed, then run `bun run check` and `bun run build`. The gate runs in the same job because a `GITHUB_TOKEN` push does not retrigger workflows, so the pushed commit would otherwise never be verified.
- **`ci.yml`**: skip the `check` job for `dependabot[bot]`, which would otherwise always fail on the frozen lockfile and leave a permanently red check next to a green one.
- **`dependabot.yml`**: ignore typescript major bumps. TS 7's native API breaks `ts-api-utils` (loaded by `typescript-eslint` and `eslint-plugin-sonarjs`), so ESLint crashes before linting anything.

## Notes

No untrusted input is interpolated into any `run:` block. `contents: write` is scoped to this workflow, and dependabot branches live in this repo rather than a fork. Bun does not execute lifecycle scripts for untrusted dependencies by default, which limits install-time exposure of the token.