### PR TITLE
fix(ui): render the freetext choice enabled by allowOther

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,5 @@
 /** Default timeout for waiting for user answers (5 minutes) */
 export const DEFAULT_ANSWER_TIMEOUT_MS = 300000;
+
+/** Option id reserved for the freetext choice enabled by `allowOther` */
+export const OTHER_OPTION_ID = "other";

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -68,10 +68,14 @@ export const QUESTION_TYPES = Object.values(QUESTIONS);
 
 export interface PickOneAnswer {
   selected: string;
+  /** Freetext supplied when `selected` is the reserved "other" id */
+  other?: string;
 }
 
 export interface PickManyAnswer {
   selected: string[];
+  /** Freetext supplied when `selected` contains the reserved "other" id */
+  other?: string;
 }
 
 export interface ConfirmAnswer {

--- a/src/tools/extractor.ts
+++ b/src/tools/extractor.ts
@@ -1,3 +1,4 @@
+import { OTHER_OPTION_ID } from "@/constants";
 import type { Answer, QuestionAnswers, QuestionType } from "@/session";
 import { QUESTIONS } from "@/session";
 
@@ -16,11 +17,15 @@ function truncateText(text: string): string {
 // eslint-disable-next-line max-lines-per-function -- single switch dispatch over all question types
 export function extractAnswerSummary(type: QuestionType, answer: Answer): string {
   switch (type) {
-    case QUESTIONS.PICK_ONE:
-      return typedAnswer(QUESTIONS.PICK_ONE, answer).selected;
+    case QUESTIONS.PICK_ONE: {
+      const picked = typedAnswer(QUESTIONS.PICK_ONE, answer);
+      return picked.selected === OTHER_OPTION_ID && picked.other ? picked.other : picked.selected;
+    }
 
-    case QUESTIONS.PICK_MANY:
-      return typedAnswer(QUESTIONS.PICK_MANY, answer).selected.join(", ");
+    case QUESTIONS.PICK_MANY: {
+      const picked = typedAnswer(QUESTIONS.PICK_MANY, answer);
+      return picked.selected.map((id) => (id === OTHER_OPTION_ID && picked.other ? picked.other : id)).join(", ");
+    }
 
     case QUESTIONS.CONFIRM:
       return typedAnswer(QUESTIONS.CONFIRM, answer).choice;

--- a/src/tools/questions.ts
+++ b/src/tools/questions.ts
@@ -33,7 +33,8 @@ function buildPickOne(createTool: ToolFactory): OcttoTool {
   return createTool<PickOneConfig & { session_id: string }>({
     type: "pick_one",
     description: `Ask user to select ONE option from a list.
-Response format: { selected: string } where selected is the chosen option id.`,
+Response format: { selected: string } where selected is the chosen option id.
+With allowOther, the user may answer "other": then selected is "other" and the freetext is in the other field.`,
     args: {
       question: tool.schema.string().describe(QUESTION_DESCRIPTION),
       options: optionsSchema,
@@ -54,7 +55,8 @@ function buildPickMany(createTool: ToolFactory): OcttoTool {
   return createTool<PickManyConfig & { session_id: string }>({
     type: "pick_many",
     description: `Ask user to select MULTIPLE options from a list.
-Response format: { selected: string[] } where selected is array of chosen option ids.`,
+Response format: { selected: string[] } where selected is array of chosen option ids.
+With allowOther, the user may add "other": then selected contains "other" and the freetext is in the other field.`,
     args: {
       question: tool.schema.string().describe(QUESTION_DESCRIPTION),
       options: optionsSchema,

--- a/src/ui/bundle.ts
+++ b/src/ui/bundle.ts
@@ -481,6 +481,10 @@ export function getHtmlBundle(): string {
       color: var(--foreground-muted);
     }
 
+    .other-input {
+      margin-top: 0.5rem;
+    }
+
     .feedback-input {
       margin-top: 1rem;
     }
@@ -913,9 +917,30 @@ export function getHtmlBundle(): string {
         if (opt.description) html += '<div class="option-desc">' + escapeHtml(opt.description) + '</div>';
         html += '</div></label>';
       }
+      if (q.config.allowOther) html += renderOtherOption(q, 'radio');
       html += '</div>';
       html += '<div class="btn-group"><button onclick="submitPickOne(\\'' + q.id + '\\')" class="btn btn-primary">Submit</button></div>';
       return html;
+    }
+
+    function renderOtherOption(q, inputType) {
+      let html = '<label class="option">';
+      html += '<input type="' + inputType + '" name="pick_' + q.id + '" id="otherchoice_' + q.id + '" value="other">';
+      html += '<div class="option-content"><div class="option-label">Other</div></div>';
+      html += '</label>';
+      // Kept outside the label: nesting it would make a click activate the label's control instead of focusing the field.
+      html += '<input type="text" class="input other-input" id="other_' + q.id + '" placeholder="Type your own answer" onfocus="selectOther(\\'' + q.id + '\\')">';
+      return html;
+    }
+
+    function selectOther(questionId) {
+      const choice = document.getElementById('otherchoice_' + questionId);
+      if (choice) choice.checked = true;
+    }
+
+    function readOther(questionId) {
+      const input = document.getElementById('other_' + questionId);
+      return input ? input.value.trim() : '';
     }
     
     function renderPickMany(q) {
@@ -929,6 +954,7 @@ export function getHtmlBundle(): string {
         if (opt.description) html += '<div class="option-desc">' + escapeHtml(opt.description) + '</div>';
         html += '</div></label>';
       }
+      if (q.config.allowOther) html += renderOtherOption(q, 'checkbox');
       html += '</div>';
       html += '<div class="btn-group"><button onclick="submitPickMany(\\'' + q.id + '\\')" class="btn btn-primary">Submit</button></div>';
       return html;
@@ -1197,11 +1223,29 @@ export function getHtmlBundle(): string {
         showError(questionId, 'Please select an option');
         return;
       }
+      if (selected.value === 'other') {
+        const other = readOther(questionId);
+        if (!other) {
+          showError(questionId, 'Please describe your other answer');
+          return;
+        }
+        submitAnswer(questionId, { selected: 'other', other });
+        return;
+      }
       submitAnswer(questionId, { selected: selected.value });
     }
-    
+
     function submitPickMany(questionId) {
       const selected = Array.from(document.querySelectorAll('input[name="pick_' + questionId + '"]:checked')).map(el => el.value);
+      if (selected.includes('other')) {
+        const other = readOther(questionId);
+        if (!other) {
+          showError(questionId, 'Please describe your other answer');
+          return;
+        }
+        submitAnswer(questionId, { selected, other });
+        return;
+      }
       submitAnswer(questionId, { selected });
     }
     

--- a/tests/session/sessions.test.ts
+++ b/tests/session/sessions.test.ts
@@ -280,5 +280,46 @@ describe("createSessionStore", () => {
         expect(result2.question_id).toBe(q2_id);
       });
     });
+
+    describe("freetext answers", () => {
+      it("should deliver the other freetext of a pick_one answer to a blocked caller", async () => {
+        const { session_id } = await sessions.startSession({});
+        const { question_id } = sessions.pushQuestion(session_id, "pick_one", {
+          question: "Which datastore?",
+          options: [{ id: "redis", label: "Redis" }],
+          allowOther: true,
+        });
+
+        const wait = sessions.getAnswer({ question_id, block: true, timeout: 1000 });
+        sessions.handleWsMessage(session_id, {
+          type: "response",
+          id: question_id,
+          answer: { selected: "other", other: "SQLite with Litestream" },
+        });
+
+        const result = await wait;
+        expect(result.completed).toBe(true);
+        expect(result.response).toEqual({ selected: "other", other: "SQLite with Litestream" });
+      });
+
+      it("should deliver a pick_many answer mixing option ids with other freetext", async () => {
+        const { session_id } = await sessions.startSession({});
+        const { question_id } = sessions.pushQuestion(session_id, "pick_many", {
+          question: "Which caches?",
+          options: [{ id: "redis", label: "Redis" }],
+          allowOther: true,
+        });
+
+        const wait = sessions.getAnswer({ question_id, block: true, timeout: 1000 });
+        sessions.handleWsMessage(session_id, {
+          type: "response",
+          id: question_id,
+          answer: { selected: ["redis", "other"], other: "Dragonfly" },
+        });
+
+        const result = await wait;
+        expect(result.response).toEqual({ selected: ["redis", "other"], other: "Dragonfly" });
+      });
+    });
   });
 });

--- a/tests/tools/extractor.test.ts
+++ b/tests/tools/extractor.test.ts
@@ -14,6 +14,21 @@ describe("extractAnswerSummary", () => {
     expect(result).toBe("a, b, c");
   });
 
+  it("should extract the freetext when pick_one is answered with other", () => {
+    const result = extractAnswerSummary("pick_one", { selected: "other", other: "use Postgres instead" });
+    expect(result).toBe("use Postgres instead");
+  });
+
+  it("should extract the freetext alongside selections when pick_many includes other", () => {
+    const result = extractAnswerSummary("pick_many", { selected: ["redis", "other"], other: "also NATS" });
+    expect(result).toBe("redis, also NATS");
+  });
+
+  it("should ignore a stray other field when other was not selected", () => {
+    const result = extractAnswerSummary("pick_one", { selected: "option_a", other: "leftover" });
+    expect(result).toBe("option_a");
+  });
+
   it("should extract confirm answer", () => {
     const result = extractAnswerSummary("confirm", { choice: "yes" });
     expect(result).toBe("yes");


### PR DESCRIPTION
Closes the second half of #7.

## The bug

`allowOther` was declared in four schemas (`pick_one`, `pick_many`, `start_session`, `push_question`) and described to the model as "Allow custom 'other' input". It was stored into the question config and sent to the browser. Nothing ever rendered it:

```js
function renderPickOne(q) {
  const options = q.config.options || [];   // allowOther never consulted
```

Neither submit handler could produce a custom value either. The flag was a no-op that the model was actively told about, which is why the reporter said "no matter how much I instruct it" — no amount of prompting can make a no-op work.

#28 fixed the *transport* for this flag (it was previously stripped by `looseObject` on the `start_session`/`push_question` paths), so the flag now reaches the browser. This makes the browser do something with it.

## Encoding

The freetext comes back as a distinct field, so the agent can always tell it from an option id:

```js
// pick_one
{ selected: "other", other: "SQLite with Litestream" }
// pick_many
{ selected: ["redis", "other"], other: "Dragonfly" }
```

`PickOneAnswer`/`PickManyAnswer` gain an optional `other`, and both tool descriptions now document it. `extractAnswerSummary` substitutes the freetext so summaries read `SQLite with Litestream` rather than `other`.

## Verification

The UI bundle is a template string with no test harness, so the rendering and submit paths were verified by running a real session in Chrome. Three paths, each confirmed against the answer the store actually delivered:

| Path | Result |
|---|---|
| `pick_one`, Other + freetext | `{"selected":"other","other":"SQLite with Litestream"}` |
| `pick_many`, Other checked, text empty | `Please describe your other answer`, no submit |
| `pick_many`, Redis + Other | `{"selected":["redis","other"],"other":"Dragonfly"}` |

That browser run caught a bug the unit tests could not: the text field was initially nested inside the `<label>`, so clicking it activated the label's radio instead of focusing the field, and typing went nowhere. It now sits outside the label, with `onfocus` selecting the choice. There is a comment on that line so it does not get "tidied" back in.

Non-browser regression tests cover the answer contract: `extractAnswerSummary` for both types plus a stray-`other` case, and two session round-trips asserting the freetext reaches a blocked caller.

`bun run check`: 235 pass, 0 fail. `bun run build` clean.

## Not covered

The first half of #7, where the agent stops following up after answers, is a separate problem and is being looked at on its own.