### PR TITLE
fix(brainstorm): stop telling the agent to run its own answer loop

### DIFF
--- a/src/tools/brainstorm.ts
+++ b/src/tools/brainstorm.ts
@@ -29,9 +29,19 @@ const branchesSchema = tool.schema
   )
   .describe("Branches to explore");
 
+/** Why answer collection stopped, so an unfinished session can explain itself to the agent. */
+const COLLECTION_STOPS = {
+  COMPLETE: "complete",
+  NO_ANSWER_WITHIN_TIMEOUT: "no_answer_within_timeout",
+  ITERATION_CAP: "iteration_cap",
+} as const;
+
+type CollectionStop = (typeof COLLECTION_STOPS)[keyof typeof COLLECTION_STOPS];
+
 interface CollectionResult {
   state: BrainstormState | null;
   allComplete: boolean;
+  stoppedBecause: CollectionStop;
 }
 
 function enqueueAnswerProcessing(
@@ -113,9 +123,13 @@ async function collectAnswers(
   client: OpencodeClient,
 ): Promise<CollectionResult> {
   const pending: Promise<void>[] = [];
+  let stoppedBecause: CollectionStop = COLLECTION_STOPS.ITERATION_CAP;
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
-    if (await stateStore.isSessionComplete(sessionId)) break;
+    if (await stateStore.isSessionComplete(sessionId)) {
+      stoppedBecause = COLLECTION_STOPS.COMPLETE;
+      break;
+    }
 
     const answer = await sessions.getNextAnswer({
       session_id: browserSessionId,
@@ -124,7 +138,10 @@ async function collectAnswers(
     });
 
     const action = await processOneAnswer(answer, pending, stateStore, sessions, sessionId, browserSessionId, client);
-    if (action === "break") break;
+    if (action === "break") {
+      stoppedBecause = COLLECTION_STOPS.NO_ANSWER_WITHIN_TIMEOUT;
+      break;
+    }
   }
 
   await Promise.all(pending);
@@ -134,7 +151,7 @@ async function collectAnswers(
     stateStore.isSessionComplete(sessionId),
   ]);
 
-  return { state, allComplete };
+  return { state, allComplete, stoppedBecause };
 }
 
 interface ReviewSection {
@@ -188,14 +205,19 @@ async function waitForReviewApproval(sessions: SessionStore, browserSessionId: s
   };
 }
 
-function formatInProgressResult(state: BrainstormState): string {
+function formatInProgressResult(state: BrainstormState, stoppedBecause: CollectionStop): string {
   const branches = state.branch_order.map((id) => formatBranchStatus(state.branches[id])).join("\n");
+  const reason =
+    stoppedBecause === COLLECTION_STOPS.ITERATION_CAP
+      ? `Collected ${MAX_ITERATIONS} answers in one call, the per-call limit.`
+      : "No answer arrived within the wait window; the user is still thinking.";
   return `<brainstorm_in_progress>
   <request>${state.request}</request>
   <branches>
 ${branches}
   </branches>
-  <next_action>Call await_brainstorm_complete again to continue</next_action>
+  <reason>${reason}</reason>
+  <next_action>The brainstorm is NOT finished and no branch was abandoned. Call await_brainstorm_complete again immediately with the same ids. Do not summarize, do not write the design document, and do not ask the user anything.</next_action>
 </brainstorm_in_progress>`;
 }
 
@@ -289,7 +311,7 @@ function buildCreateBrainstormTool(store: StateStore, sessions: SessionStore): O
   <branches>
 ${branchesXml}
   </branches>
-  <next_action>Call get_next_answer(session_id="${browserSession.session_id}", block=true)</next_action>
+  <next_action>Call await_brainstorm_complete(session_id="${sessionId}", browser_session_id="${browserSession.session_id}"). Do not loop on get_next_answer yourself: it does not record findings into branch state.</next_action>
 </brainstorm_created>`;
     },
   });
@@ -359,7 +381,7 @@ This is the recommended way to run a brainstorm - just create_brainstorm then aw
       browser_session_id: tool.schema.string().describe("Browser session ID (for collecting answers)"),
     },
     execute: async (args) => {
-      const { state, allComplete } = await collectAnswers(
+      const { state, allComplete, stoppedBecause } = await collectAnswers(
         store,
         sessions,
         args.session_id,
@@ -368,7 +390,7 @@ This is the recommended way to run a brainstorm - just create_brainstorm then aw
       );
 
       if (!state) return "<error>Session lost</error>";
-      if (!allComplete) return formatInProgressResult(state);
+      if (!allComplete) return formatInProgressResult(state, stoppedBecause);
 
       const sections = buildReviewSections(state);
 

--- a/tests/tools/brainstorm.test.ts
+++ b/tests/tools/brainstorm.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 import { createSessionStore } from "../../src/session/sessions";
 import { createBrainstormTools } from "../../src/tools/brainstorm";
+import { outputText } from "../../src/tools/output";
 
 describe("Brainstorm Tools", () => {
   let sessions: ReturnType<typeof createSessionStore>;
@@ -44,6 +45,31 @@ describe("Brainstorm Tools", () => {
 
       expect(result).toContain("ses_");
       expect(result).toContain("services");
+    });
+
+    it("should point the agent at await_brainstorm_complete rather than a manual answer loop", async () => {
+      const result = outputText(
+        await tools.create_brainstorm.execute(
+          {
+            request: "Add healthcheck",
+            branches: [
+              {
+                id: "services",
+                scope: "Which services to monitor",
+                initial_question: {
+                  type: "ask_text",
+                  config: { question: "What services?" },
+                },
+              },
+            ],
+          },
+          {} as any,
+        ),
+      );
+
+      const nextAction = result.slice(result.indexOf("<next_action>"), result.indexOf("</next_action>"));
+      expect(nextAction).toContain("await_brainstorm_complete");
+      expect(nextAction).not.toContain("Call get_next_answer");
     });
   });
 });


### PR DESCRIPTION
Partial fix for the first half of #7 and the reliability complaint in #13. See the investigation notes below for what this does and does not address.

## Finding 1: the tool contradicted the agent prompt

`create_brainstorm` returned:

```
<next_action>Call get_next_answer(session_id="...", block=true)</next_action>
```

while `src/agents/octto.ts` forbids exactly that:

```
<forbidden>NEVER manually loop with get_next_answer - use await_brainstorm_complete instead</forbidden>
```

The model hits this contradiction at precisely the point where it decides what to do next, and the two branches behave very differently: a manual `get_next_answer` loop returns answers but never runs `processAnswer`, so nothing lands in branch state and no probe follow-ups are spawned. That is a good candidate for #13's "sometimes this works! but it's not reliable".

Now points at `await_brainstorm_complete`, with a regression test asserting the `next_action` names it and does not tell the agent to loop. Mutation-checked: restoring the old string fails the test.

## Finding 2: an unfinished session looked identical to a finished one

`collectAnswers` blocks per answer on `DEFAULT_ANSWER_TIMEOUT_MS` (5 minutes). On timeout `processOneAnswer` returns `break`, the loop exits, and the tool returns `formatInProgressResult` whose entire continuation was:

```
<next_action>Call await_brainstorm_complete again to continue</next_action>
```

Whether the brainstorm continues then depends on the model volunteering another call. If it does not, the user sees #7 exactly: answers stored correctly, agent idle, no follow-up until they interrupt. Five minutes is an easy threshold to cross while thinking about a design question. The `MAX_ITERATIONS = 50` exit produced the same output with no way to tell the two apart.

The in-progress result now reports which of the two happened and states plainly that the session is unfinished, that no branch was abandoned, and that the agent must not summarize or write the design document yet.

## What this does not fix

This makes the hint much harder to misread. It does not make follow-through *enforced* — after a timeout, control is still with the model. The structural fix is to stop treating "no answer in 5 minutes" as a reason to hand control back at all, and instead keep waiting while the browser session is alive with questions outstanding. That changes the tool's blocking contract, so I have left it out of this PR.

`bun run check`: 231 pass, 0 fail.