### PR TITLE
test(e2e): dockerised end-to-end harness for octto inside opencode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+e2e/node_modules
+docs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: End-to-end
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      live_model:
+        description: "Run the live-model tier with this model (e.g. anthropic/claude-sonnet-5)"
+        required: false
+        type: string
+
+jobs:
+  scripted:
+    # The scripted tier is deterministic and free, so it runs on every PR.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build harness
+        run: docker build -f e2e/Dockerfile -t octto-e2e .
+
+      - name: Run scripted tier
+        run: docker run --rm octto-e2e
+
+  live:
+    # Costs money and needs a real model, so it is manual only and skips
+    # without a key rather than failing.
+    if: github.event_name == 'workflow_dispatch' && inputs.live_model != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build harness
+        run: docker build -f e2e/Dockerfile -t octto-e2e .
+
+      - name: Run live tier
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LIVE_MODEL: ${{ inputs.live_model }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "No ANTHROPIC_API_KEY secret configured; skipping live tier."
+            exit 0
+          fi
+          docker run --rm \
+            -e ANTHROPIC_API_KEY \
+            -e OCTTO_E2E_LIVE_MODEL="${LIVE_MODEL}" \
+            octto-e2e

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,66 @@
+FROM oven/bun:1-debian
+
+# chromium for the real browser, xvfb for a display, xdg-utils so octto's
+# openBrowser() (which shells out to xdg-open on Linux) exercises its real path.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      chromium \
+      xvfb \
+      xdg-utils \
+      fonts-liberation \
+      ca-certificates \
+      curl \
+      unzip \
+      procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# The installer's layout varies by version, so locate the binary rather than
+# assume a path, and fail loudly if it is missing.
+RUN curl -fsSL https://opencode.ai/install | bash \
+    && OPENCODE_BIN="$(find / -type f -name opencode -perm -u+x 2>/dev/null | head -1)" \
+    && test -n "${OPENCODE_BIN}" \
+    && ln -sf "${OPENCODE_BIN}" /usr/local/bin/opencode \
+    && opencode --version
+
+# xdg-open must reach the SAME chromium instance the tests drive over CDP.
+# Without a matching --user-data-dir, chromium starts a second, unobservable
+# instance instead of opening a tab in the running one.
+RUN printf '%s\n' \
+      '[Desktop Entry]' \
+      'Version=1.0' \
+      'Name=Octto Chromium' \
+      'Exec=/usr/bin/chromium --user-data-dir=/tmp/chrome-profile --no-sandbox --disable-gpu --disable-dev-shm-usage %U' \
+      'Terminal=false' \
+      'Type=Application' \
+      'MimeType=text/html;x-scheme-handler/http;x-scheme-handler/https;' \
+      > /usr/share/applications/octto-chromium.desktop \
+    && update-desktop-database /usr/share/applications || true
+
+# System-wide default, because each test isolates HOME for opencode's config
+# and would otherwise lose a per-user xdg-settings association.
+RUN printf '%s\n' \
+      '[Default Applications]' \
+      'text/html=octto-chromium.desktop' \
+      'x-scheme-handler/http=octto-chromium.desktop' \
+      'x-scheme-handler/https=octto-chromium.desktop' \
+      > /etc/xdg/mimeapps.list
+
+WORKDIR /work
+
+# Dependencies first so source edits do not bust the layer cache.
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --ignore-scripts
+
+COPY e2e/package.json ./e2e/package.json
+RUN cd e2e && bun install --ignore-scripts
+
+COPY . .
+RUN bun run build
+
+ENV DISPLAY=:99 \
+    CHROME_BIN=/usr/bin/chromium \
+    CDP_PORT=9222 \
+    OCTTO_PORT=7777 \
+    STUB_PORT=8787
+
+ENTRYPOINT ["/work/e2e/entrypoint.sh"]
+CMD ["bun", "test", "e2e/specs", "--timeout", "200000"]

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,54 @@
+# End-to-end harness
+
+Runs octto inside a real opencode session, in a container, against a real browser.
+
+```bash
+bun run test:e2e
+```
+
+## What is real, and what is not
+
+Real: the opencode runtime, the octto plugin loaded the way users load it, Chromium
+under Xvfb reached through octto's own `xdg-open` call, the session HTTP server, and
+the websocket answer round-trip.
+
+Faked: only the model. A scripted OpenAI-compatible provider (`stub-provider/`)
+replays a fixed list of tool calls, so a run is deterministic, offline and free.
+
+This split is deliberate. It catches integration breaks (plugin fails to load, browser
+never opens, UI stops rendering a field, answers stop reaching the agent) without the
+flakiness and cost of a live model.
+
+**It cannot catch prompt-adherence bugs**, where the model simply fails to make the
+next call. Issue #7's follow-up bug is exactly that class, so a live-model tier is
+still needed to guard it.
+
+## Scripts
+
+A script is an ordered list of assistant turns. Turn N answers the request carrying N
+prior assistant messages, which keeps the stub stateless across retries.
+
+```json
+[
+  { "tool": "start_session", "args": { "title": "…", "questions": [ … ] } },
+  { "tool": "get_next_answer", "args": { "session_id": { "$extract": "ses_[a-z0-9]+" } } },
+  { "text": "E2E_DONE" }
+]
+```
+
+Session ids are minted at runtime and cannot be hardcoded, so `{"$extract": "<regex>"}`
+is replaced by the last match seen anywhere in the conversation so far.
+
+## Notes for future work
+
+- Local plugins load by **absolute path in the `plugin` array**. The documented
+  `.opencode/plugins/` directory did not load them.
+- opencode has no config-dir env var; isolation is done by overriding `HOME`. Because
+  each spec gets its own `HOME`, the default browser association must be system-wide
+  (`/etc/xdg/mimeapps.list`), not per-user.
+- Chrome is driven over raw CDP. `playwright-core` hangs on the websocket handshake
+  under Bun, while a plain `WebSocket` works.
+- `xdg-open` must launch Chromium with the **same** `--user-data-dir` as the
+  CDP-enabled instance, or it silently starts a second, unobservable browser.
+- Unit tests are scoped with `bun test tests`. Bun treats that argument as a substring
+  filter, so the e2e specs live in `e2e/specs/` to stay out of the normal gate.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,8 +20,23 @@ never opens, UI stops rendering a field, answers stop reaching the agent) withou
 flakiness and cost of a live model.
 
 **It cannot catch prompt-adherence bugs**, where the model simply fails to make the
-next call. Issue #7's follow-up bug is exactly that class, so a live-model tier is
-still needed to guard it.
+next call. Issue #7's follow-up bug is exactly that class, which is what the second
+tier is for.
+
+## Live tier
+
+```bash
+docker run --rm -e ANTHROPIC_API_KEY \
+  -e OCTTO_E2E_LIVE_MODEL=anthropic/claude-sonnet-5 octto-e2e
+```
+
+Same container, real provider, no script: a real model is asked to run the loop, and
+the spec checks it follows through *unprompted* once the answer lands. That is the
+only way to catch the #7 class of bug.
+
+Skipped when `OCTTO_E2E_LIVE_MODEL` is unset, so the default suite stays free and
+deterministic. In CI it is `workflow_dispatch` only, and exits cleanly rather than
+failing when no key is configured.
 
 ## Scripts
 

--- a/e2e/entrypoint.sh
+++ b/e2e/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[entrypoint] $*"; }
+
+cleanup() {
+  jobs -p | xargs -r kill 2>/dev/null || true
+}
+trap cleanup EXIT
+
+log "starting Xvfb on ${DISPLAY}"
+Xvfb "${DISPLAY}" -screen 0 1280x1024x24 -nolisten tcp &
+
+for _ in $(seq 1 50); do
+  xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1 || { log "Xvfb never came up"; exit 1; }
+
+# Chromium must already be running with CDP open: a later `xdg-open URL` then
+# lands as a new tab in this instance, which is what the tests attach to.
+log "starting chromium with CDP on ${CDP_PORT}"
+"${CHROME_BIN}" \
+  --remote-debugging-port="${CDP_PORT}" \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-allow-origins='*' \
+  --no-sandbox \
+  --disable-gpu \
+  --disable-dev-shm-usage \
+  --no-first-run \
+  --no-default-browser-check \
+  --user-data-dir=/tmp/chrome-profile \
+  about:blank >/tmp/chromium.log 2>&1 &
+
+for _ in $(seq 1 100); do
+  curl -sf "http://127.0.0.1:${CDP_PORT}/json/version" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -sf "http://127.0.0.1:${CDP_PORT}/json/version" >/dev/null 2>&1 || {
+  log "chromium CDP never came up"; tail -40 /tmp/chromium.log; exit 1;
+}
+
+# Make xdg-open resolve to this chromium, so octto's openBrowser() reaches it.
+xdg-settings set default-web-browser octto-chromium.desktop 2>/dev/null \
+  || log "xdg-settings failed; relying on xdg-open fallback"
+
+log "ready: $(curl -s "http://127.0.0.1:${CDP_PORT}/json/version" | head -c 120)"
+
+exec "$@"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "octto-e2e",
+  "private": true
+}

--- a/e2e/scripts/allow-other.json
+++ b/e2e/scripts/allow-other.json
@@ -1,0 +1,31 @@
+[
+  {
+    "tool": "start_session",
+    "args": {
+      "title": "e2e allowOther",
+      "questions": [
+        {
+          "type": "pick_one",
+          "config": {
+            "question": "Which datastore should we use?",
+            "options": [{ "id": "redis", "label": "Redis" }, { "id": "postgres", "label": "Postgres" }],
+            "allowOther": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "tool": "get_next_answer",
+    "args": {
+      "session_id": { "$extract": "ses_[a-z0-9]+" },
+      "block": true,
+      "timeout": 120000
+    }
+  },
+  {
+    "tool": "end_session",
+    "args": { "session_id": { "$extract": "ses_[a-z0-9]+" } }
+  },
+  { "text": "E2E_DONE" }
+]

--- a/e2e/scripts/live-followup.md
+++ b/e2e/scripts/live-followup.md
@@ -1,0 +1,3 @@
+Use octto to ask me exactly one question: a pick_one titled "Which datastore should we use?"
+with options redis and postgres, and allowOther enabled. Then wait for my answer and, once
+you have it, reply with the single line E2E_LIVE_OK followed by the answer you received.

--- a/e2e/specs/allow-other.test.ts
+++ b/e2e/specs/allow-other.test.ts
@@ -7,8 +7,8 @@ import { join } from "node:path";
 import { type CdpSession, connect, waitForTarget, waitInPage } from "./cdp";
 import {
   cdpPort,
-  collectRun,
   octtoPort,
+  readUntil,
   type StubHandle,
   spawnOpencode,
   startStub,
@@ -20,6 +20,7 @@ const SCRIPT = join(import.meta.dir, "..", "scripts", "allow-other.json");
 const FREETEXT = "SQLite with Litestream";
 const TAB_TIMEOUT_MS = 60_000;
 const RENDER_TIMEOUT_MS = 30_000;
+const RUN_TIMEOUT_MS = 90_000;
 
 describe("octto inside a real opencode session", () => {
   let stub: StubHandle;
@@ -69,10 +70,13 @@ describe("octto inside a real opencode session", () => {
 
     expect(submitted).toBe(true);
 
-    const { stdout, exitCode } = await collectRun(run);
+    // The freetext must come back through the tool result the agent sees.
+    const stdout = await readUntil(run, [FREETEXT, "Answer Received"], RUN_TIMEOUT_MS);
 
-    expect(exitCode).toBe(0);
     expect(stdout).toContain(FREETEXT);
-    expect(stdout).toContain("E2E_DONE");
+    // The event stream is JSON-escaped, so compare against a normalised copy.
+    const unescaped = stdout.replace(/\\+"/g, '"');
+    expect(unescaped).toContain(`"selected": "other"`);
+    expect(unescaped).toContain(`"other": "${FREETEXT}"`);
   }, 180_000);
 });

--- a/e2e/specs/allow-other.test.ts
+++ b/e2e/specs/allow-other.test.ts
@@ -1,0 +1,78 @@
+// e2e/tests/allow-other.test.ts
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { type CdpSession, connect, waitForTarget, waitInPage } from "./cdp";
+import {
+  cdpPort,
+  collectRun,
+  octtoPort,
+  type StubHandle,
+  spawnOpencode,
+  startStub,
+  writeOpencodeConfig,
+} from "./harness";
+
+const PLUGIN_PATH = "/work/dist/index.js";
+const SCRIPT = join(import.meta.dir, "..", "scripts", "allow-other.json");
+const FREETEXT = "SQLite with Litestream";
+const TAB_TIMEOUT_MS = 60_000;
+const RENDER_TIMEOUT_MS = 30_000;
+
+describe("octto inside a real opencode session", () => {
+  let stub: StubHandle;
+  let home: string;
+  let page: CdpSession | undefined;
+
+  beforeAll(async () => {
+    home = mkdtempSync(join(tmpdir(), "octto-e2e-home-"));
+    stub = await startStub(SCRIPT);
+    writeOpencodeConfig(home, [PLUGIN_PATH]);
+  });
+
+  afterAll(() => {
+    page?.close();
+    stub?.stop();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("should open a real browser and round-trip an allowOther freetext answer back to the agent", async () => {
+    const run = spawnOpencode(home, "build", "Ask the user which datastore we should use.");
+
+    // Reaching this tab proves octto's openBrowser() -> xdg-open path worked,
+    // not merely that its HTTP server was listening.
+    const target = await waitForTarget(cdpPort(), `http://localhost:${octtoPort()}`, TAB_TIMEOUT_MS);
+    page = await connect(target.webSocketDebuggerUrl ?? "");
+
+    await waitInPage(
+      page,
+      `document.body.innerText.includes("Which datastore should we use?")`,
+      "question text",
+      RENDER_TIMEOUT_MS,
+    );
+
+    // The freetext field exists only once the UI actually honours allowOther.
+    await waitInPage(page, `document.querySelector("[id^='other_']")`, "other freetext field", RENDER_TIMEOUT_MS);
+
+    const submitted = await page.evaluate<boolean>(`(() => {
+      const input = document.querySelector("[id^='other_']");
+      if (!input) return false;
+      input.focus();
+      input.value = ${JSON.stringify(FREETEXT)};
+      const submit = [...document.querySelectorAll("button")].find((b) => b.textContent.trim().toLowerCase() === "submit");
+      if (!submit) return false;
+      submit.click();
+      return true;
+    })()`);
+
+    expect(submitted).toBe(true);
+
+    const { stdout, exitCode } = await collectRun(run);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(FREETEXT);
+    expect(stdout).toContain("E2E_DONE");
+  }, 180_000);
+});

--- a/e2e/specs/cdp.ts
+++ b/e2e/specs/cdp.ts
@@ -1,0 +1,146 @@
+/**
+ * Minimal Chrome DevTools Protocol client.
+ *
+ * playwright-core hangs on the CDP websocket handshake under Bun, while a raw
+ * WebSocket connects fine, so the suite talks to Chrome directly. Everything
+ * needed here is Runtime.evaluate against a page target.
+ */
+
+const POLL_MS = 100;
+const CONNECT_TIMEOUT_MS = 10_000;
+const EVAL_TIMEOUT_MS = 15_000;
+const EXPR_PREVIEW_CHARS = 60;
+const ERROR_PREVIEW_CHARS = 300;
+
+export interface CdpTarget {
+  readonly id: string;
+  readonly type: string;
+  readonly url: string;
+  readonly webSocketDebuggerUrl?: string;
+}
+
+export interface CdpSession {
+  evaluate: <T>(expression: string) => Promise<T>;
+  close: () => void;
+}
+
+function isTargetList(value: unknown): value is CdpTarget[] {
+  return Array.isArray(value);
+}
+
+export async function listTargets(port: number): Promise<CdpTarget[]> {
+  const parsed: unknown = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+  return isTargetList(parsed) ? parsed : [];
+}
+
+export async function waitForTarget(port: number, urlPrefix: string, timeoutMs: number): Promise<CdpTarget> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const targets = await listTargets(port);
+    const page = targets.find((t) => t.type === "page" && t.url.startsWith(urlPrefix) && t.webSocketDebuggerUrl);
+    if (page) return page;
+    await Bun.sleep(POLL_MS);
+  }
+
+  const seen = (await listTargets(port)).map((t) => `${t.type}:${t.url}`).join(", ");
+  throw new Error(`No page target for ${urlPrefix} within ${timeoutMs}ms. Saw: ${seen || "none"}`);
+}
+
+interface CdpReply {
+  readonly id?: number;
+  readonly result?: { readonly result?: { readonly value?: unknown }; readonly exceptionDetails?: unknown };
+}
+
+function parseReply(raw: unknown): CdpReply {
+  if (typeof raw !== "string") return {};
+  const parsed: unknown = JSON.parse(raw);
+  return typeof parsed === "object" && parsed !== null ? parsed : {};
+}
+
+function awaitOpen(socket: WebSocket, wsUrl: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`CDP connect timed out: ${wsUrl}`)), CONNECT_TIMEOUT_MS);
+    socket.onopen = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    socket.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error(`CDP socket error: ${wsUrl}`));
+    };
+  });
+}
+
+function sendEvaluate<T>(
+  socket: WebSocket,
+  pending: Map<number, (reply: CdpReply) => void>,
+  id: number,
+  expression: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`CDP evaluate timed out: ${expression.slice(0, EXPR_PREVIEW_CHARS)}`)),
+      EVAL_TIMEOUT_MS,
+    );
+
+    pending.set(id, (reply) => {
+      clearTimeout(timer);
+      const failure = reply.result?.exceptionDetails;
+      if (failure) {
+        reject(new Error(`Evaluate threw: ${JSON.stringify(failure).slice(0, ERROR_PREVIEW_CHARS)}`));
+        return;
+      }
+      resolve(reply.result?.result?.value as T);
+    });
+
+    socket.send(
+      JSON.stringify({
+        id,
+        method: "Runtime.evaluate",
+        params: { expression, returnByValue: true, awaitPromise: true },
+      }),
+    );
+  });
+}
+
+export async function connect(wsUrl: string): Promise<CdpSession> {
+  const socket = new WebSocket(wsUrl);
+  const pending = new Map<number, (reply: CdpReply) => void>();
+  let nextId = 1;
+
+  socket.onmessage = (event: MessageEvent) => {
+    const reply = parseReply(event.data);
+    if (reply.id === undefined) return;
+    pending.get(reply.id)?.(reply);
+    pending.delete(reply.id);
+  };
+
+  await awaitOpen(socket, wsUrl);
+
+  return {
+    evaluate: <T>(expression: string): Promise<T> => sendEvaluate<T>(socket, pending, nextId++, expression),
+    close: () => socket.close(),
+  };
+}
+
+/** Polls an expression in the page until it reports ready, so tests never race the render. */
+export async function waitInPage(
+  session: CdpSession,
+  expression: string,
+  label: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  // The tab may still be loading, so a probe that throws counts as "not yet"
+  // rather than failing the test.
+  const guarded = `(() => { try { return Boolean(${expression}); } catch { return false; } })()`;
+
+  while (Date.now() < deadline) {
+    if (await session.evaluate<boolean>(guarded)) return;
+    await Bun.sleep(POLL_MS);
+  }
+
+  throw new Error(`Timed out waiting in page for ${label}`);
+}

--- a/e2e/specs/harness.ts
+++ b/e2e/specs/harness.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared plumbing for the end-to-end suite.
+ *
+ * Everything except the model is real: the opencode runtime, the octto plugin,
+ * the browser and the websocket round-trip. The model is a scripted stub so a
+ * run is deterministic and free.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const READY_POLL_MS = 100;
+const DEFAULT_STUB_PORT = 8787;
+const DEFAULT_OCTTO_PORT = 7777;
+const DEFAULT_CDP_PORT = 9222;
+const READY_TIMEOUT_MS = 30_000;
+
+export interface StubHandle {
+  readonly port: number;
+  stop: () => void;
+}
+
+export function stubPort(): number {
+  return Number(process.env.STUB_PORT ?? DEFAULT_STUB_PORT);
+}
+
+export function octtoPort(): number {
+  return Number(process.env.OCTTO_PORT ?? DEFAULT_OCTTO_PORT);
+}
+
+export function cdpPort(): number {
+  return Number(process.env.CDP_PORT ?? DEFAULT_CDP_PORT);
+}
+
+export async function waitUntil(check: () => Promise<boolean> | boolean, label: string): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await Bun.sleep(READY_POLL_MS);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+export async function startStub(scriptPath: string): Promise<StubHandle> {
+  const port = stubPort();
+  const proc = Bun.spawn(["bun", join(import.meta.dir, "..", "stub-provider", "server.ts")], {
+    env: { ...process.env, STUB_SCRIPT: scriptPath, STUB_PORT: String(port) },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  await waitUntil(async () => {
+    try {
+      return (await fetch(`http://127.0.0.1:${port}/health`)).ok;
+    } catch {
+      return false;
+    }
+  }, "stub provider");
+
+  return { port, stop: () => proc.kill() };
+}
+
+/**
+ * Local plugins load by absolute path in the `plugin` array. The documented
+ * `.opencode/plugins/` directory did not load them; the array does.
+ */
+export function writeOpencodeConfig(home: string, pluginPaths: readonly string[]): void {
+  const dir = join(home, ".config", "opencode");
+  mkdirSync(dir, { recursive: true });
+
+  const config = {
+    $schema: "https://opencode.ai/config.json",
+    model: "stub/stub-model",
+    provider: {
+      stub: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Stub Provider",
+        options: { baseURL: `http://127.0.0.1:${stubPort()}/v1`, apiKey: "stub-key" },
+        models: { "stub-model": { name: "Stub Model" } },
+      },
+    },
+    plugin: [...pluginPaths],
+  };
+
+  writeFileSync(join(dir, "opencode.json"), JSON.stringify(config, null, 2));
+}
+
+export interface OpencodeRun {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export function spawnOpencode(home: string, agent: string, message: string): Bun.Subprocess {
+  return Bun.spawn(
+    ["opencode", "run", "--format", "json", "--auto", "--agent", agent, "--log-level", "ERROR", message],
+    {
+      cwd: "/work",
+      env: { ...process.env, HOME: home, OCTTO_PORT: String(octtoPort()) },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+}
+
+export async function collectRun(proc: Bun.Subprocess): Promise<OpencodeRun> {
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}

--- a/e2e/specs/harness.ts
+++ b/e2e/specs/harness.ts
@@ -85,6 +85,18 @@ export function writeOpencodeConfig(home: string, pluginPaths: readonly string[]
   writeFileSync(join(dir, "opencode.json"), JSON.stringify(config, null, 2));
 }
 
+/**
+ * Config for the live tier: a real provider instead of the scripted stub.
+ * Credentials come from the ambient environment, never from a file we write.
+ */
+export function writeLiveConfig(home: string, pluginPaths: readonly string[], model: string): void {
+  const dir = join(home, ".config", "opencode");
+  mkdirSync(dir, { recursive: true });
+
+  const config = { $schema: "https://opencode.ai/config.json", model, plugin: [...pluginPaths] };
+  writeFileSync(join(dir, "opencode.json"), JSON.stringify(config, null, 2));
+}
+
 export function spawnOpencode(home: string, agent: string, message: string): Bun.Subprocess {
   return Bun.spawn(
     ["opencode", "run", "--format", "json", "--auto", "--agent", agent, "--log-level", "ERROR", message],

--- a/e2e/specs/harness.ts
+++ b/e2e/specs/harness.ts
@@ -12,6 +12,7 @@ const READY_POLL_MS = 100;
 const DEFAULT_STUB_PORT = 8787;
 const DEFAULT_OCTTO_PORT = 7777;
 const DEFAULT_CDP_PORT = 9222;
+const OUTPUT_TAIL_CHARS = 1500;
 const READY_TIMEOUT_MS = 30_000;
 
 export interface StubHandle {
@@ -84,12 +85,6 @@ export function writeOpencodeConfig(home: string, pluginPaths: readonly string[]
   writeFileSync(join(dir, "opencode.json"), JSON.stringify(config, null, 2));
 }
 
-export interface OpencodeRun {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
 export function spawnOpencode(home: string, agent: string, message: string): Bun.Subprocess {
   return Bun.spawn(
     ["opencode", "run", "--format", "json", "--auto", "--agent", agent, "--log-level", "ERROR", message],
@@ -102,11 +97,51 @@ export function spawnOpencode(home: string, agent: string, message: string): Bun
   );
 }
 
-export async function collectRun(proc: Bun.Subprocess): Promise<OpencodeRun> {
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout as ReadableStream).text(),
-    new Response(proc.stderr as ReadableStream).text(),
-    proc.exited,
-  ]);
-  return { exitCode, stdout, stderr };
+/**
+ * Reads the event stream until every marker has appeared, then stops the run.
+ *
+ * Waiting on process exit is not reliable here: octto keeps an HTTP server
+ * alive for the session, so the markers are the real completion signal.
+ */
+async function pump(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  markers: readonly string[],
+  deadline: number,
+  onChunk: (text: string) => string,
+): Promise<boolean> {
+  const decoder = new TextDecoder();
+
+  while (Date.now() < deadline) {
+    // A bare read() blocks forever once the stream goes quiet, which would
+    // strand the deadline check at the top of this loop.
+    const next: ReadableStreamReadResult<Uint8Array> | null = await Promise.race([
+      reader.read(),
+      Bun.sleep(Math.max(0, deadline - Date.now())).then(() => null),
+    ]);
+    if (!next) return false;
+
+    const seen = onChunk(next.value ? decoder.decode(next.value, { stream: true }) : "");
+    if (markers.every((m) => seen.includes(m))) return true;
+    if (next.done) return false;
+  }
+  return false;
+}
+
+export async function readUntil(proc: Bun.Subprocess, markers: readonly string[], timeoutMs: number): Promise<string> {
+  const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+  let seen = "";
+  const append = (text: string): string => {
+    seen += text;
+    return seen;
+  };
+
+  try {
+    if (await pump(reader, markers, Date.now() + timeoutMs, append)) return seen;
+  } finally {
+    reader.releaseLock();
+    proc.kill();
+  }
+
+  const missing = markers.filter((m) => !seen.includes(m));
+  throw new Error(`Never saw ${JSON.stringify(missing)} in opencode output. Got:\n${seen.slice(-OUTPUT_TAIL_CHARS)}`);
 }

--- a/e2e/specs/live-followup.test.ts
+++ b/e2e/specs/live-followup.test.ts
@@ -1,0 +1,57 @@
+// e2e/specs/live-followup.test.ts
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { type CdpSession, connect, waitForTarget, waitInPage } from "./cdp";
+import { cdpPort, octtoPort, readUntil, spawnOpencode, writeLiveConfig } from "./harness";
+
+const PLUGIN_PATH = "/work/dist/index.js";
+const PROMPT = readFileSync(join(import.meta.dir, "..", "scripts", "live-followup.md"), "utf8");
+const FREETEXT = "SQLite with Litestream";
+const TAB_TIMEOUT_MS = 90_000;
+const RENDER_TIMEOUT_MS = 60_000;
+const RUN_TIMEOUT_MS = 180_000;
+
+const LIVE_MODEL = process.env.OCTTO_E2E_LIVE_MODEL;
+
+/**
+ * The scripted tier cannot catch prompt-adherence bugs, because the script
+ * decides what the model does. This tier asks a real model to run the loop and
+ * checks it actually follows through after the answer lands, which is the
+ * failure reported in issue #7.
+ *
+ * Skipped unless OCTTO_E2E_LIVE_MODEL is set, so the default suite stays free.
+ */
+describe.skipIf(!LIVE_MODEL)("octto driven by a live model", () => {
+  it("should follow through and report the answer after the user responds", async () => {
+    const home = mkdtempSync(join(tmpdir(), "octto-e2e-live-"));
+    let page: CdpSession | undefined;
+
+    try {
+      writeLiveConfig(home, [PLUGIN_PATH], LIVE_MODEL ?? "");
+      const run = spawnOpencode(home, "build", PROMPT);
+
+      const target = await waitForTarget(cdpPort(), `http://localhost:${octtoPort()}`, TAB_TIMEOUT_MS);
+      page = await connect(target.webSocketDebuggerUrl ?? "");
+
+      await waitInPage(page, `document.querySelector("[id^='other_']")`, "other freetext field", RENDER_TIMEOUT_MS);
+
+      await page.evaluate<boolean>(`(() => {
+        const input = document.querySelector("[id^='other_']");
+        input.focus();
+        input.value = ${JSON.stringify(FREETEXT)};
+        [...document.querySelectorAll("button")].find((b) => b.textContent.trim().toLowerCase() === "submit").click();
+        return true;
+      })()`);
+
+      // The model must come back to the user unprompted once the answer lands.
+      const stdout = await readUntil(run, ["E2E_LIVE_OK"], RUN_TIMEOUT_MS);
+      expect(stdout.replace(/\\+"/g, '"')).toContain(FREETEXT);
+    } finally {
+      page?.close();
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 300_000);
+});

--- a/e2e/stub-provider/server.ts
+++ b/e2e/stub-provider/server.ts
@@ -1,0 +1,199 @@
+/**
+ * OpenAI-compatible chat-completions server that replays a fixed script.
+ *
+ * opencode drives real agents through this, so the plugin, the browser and the
+ * websocket round-trip stay genuine while the model's output becomes
+ * deterministic. Turn N of the script answers the request carrying N prior
+ * assistant messages, which keeps the server stateless across retries.
+ */
+
+const DEFAULT_PORT = 8787;
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+} as const;
+
+export interface ToolTurn {
+  readonly tool: string;
+  readonly args: Record<string, unknown>;
+}
+
+export interface TextTurn {
+  readonly text: string;
+}
+
+export type ScriptTurn = ToolTurn | TextTurn;
+
+interface ChatMessage {
+  readonly role: string;
+  readonly content?: unknown;
+}
+
+/**
+ * Scripts cannot hardcode ids the tools mint at runtime, so an argument of the
+ * form {"$extract": "<regex>"} is replaced by the last match seen anywhere in
+ * the conversation so far.
+ */
+interface ExtractRef {
+  readonly $extract: string;
+}
+
+function isExtractRef(value: unknown): value is ExtractRef {
+  return typeof value === "object" && value !== null && "$extract" in value;
+}
+
+function lastMatch(messages: readonly ChatMessage[], pattern: string): string {
+  const regex = new RegExp(pattern, "g");
+  const matches = messages.flatMap((m) => JSON.stringify(m.content ?? "").match(regex) ?? []);
+  const found = matches.at(-1);
+  if (!found) throw new Error(`No match for /${pattern}/ in conversation so far`);
+  return found;
+}
+
+function resolveArgs(args: Record<string, unknown>, messages: readonly ChatMessage[]): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(args).map(([key, value]) => [
+      key,
+      isExtractRef(value) ? lastMatch(messages, value.$extract) : value,
+    ]),
+  );
+}
+
+interface ChatRequest {
+  readonly model?: string;
+  readonly messages?: readonly ChatMessage[];
+  readonly stream?: boolean;
+}
+
+function isToolTurn(turn: ScriptTurn): turn is ToolTurn {
+  return "tool" in turn;
+}
+
+function isChatRequest(body: unknown): body is ChatRequest {
+  return typeof body === "object" && body !== null;
+}
+
+function isScriptTurn(value: unknown): value is ScriptTurn {
+  return typeof value === "object" && value !== null && ("tool" in value || "text" in value);
+}
+
+async function loadScript(path: string): Promise<readonly ScriptTurn[]> {
+  const parsed: unknown = await Bun.file(path).json();
+  if (!Array.isArray(parsed)) throw new Error(`Script ${path} must be a JSON array of turns`);
+
+  const turns: unknown[] = parsed;
+  if (!turns.every(isScriptTurn)) throw new Error(`Script ${path} turns must be {tool,args} or {text}`);
+  return turns;
+}
+
+function assistantTurnsSoFar(request: ChatRequest): number {
+  return (request.messages ?? []).filter((m) => m.role === "assistant").length;
+}
+
+function chunk(model: string, delta: Record<string, unknown>, finish: string | null): string {
+  const payload = {
+    id: "chatcmpl-stub",
+    object: "chat.completion.chunk",
+    created: 0,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  };
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function streamTurn(model: string, turn: ScriptTurn, args: Record<string, unknown>): string {
+  const head = chunk(model, { role: "assistant" }, null);
+
+  if (!isToolTurn(turn)) {
+    return `${head + chunk(model, { content: turn.text }, null) + chunk(model, {}, "stop")}data: [DONE]\n\n`;
+  }
+
+  const call = chunk(
+    model,
+    {
+      tool_calls: [
+        {
+          index: 0,
+          id: `call_${turn.tool}`,
+          type: "function",
+          function: { name: turn.tool, arguments: JSON.stringify(args) },
+        },
+      ],
+    },
+    null,
+  );
+  return `${head + call + chunk(model, {}, "tool_calls")}data: [DONE]\n\n`;
+}
+
+function completionBody(model: string, turn: ScriptTurn, args: Record<string, unknown>): Record<string, unknown> {
+  const message = isToolTurn(turn)
+    ? {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: `call_${turn.tool}`,
+            type: "function",
+            function: { name: turn.tool, arguments: JSON.stringify(args) },
+          },
+        ],
+      }
+    : { role: "assistant", content: turn.text };
+
+  return {
+    id: "chatcmpl-stub",
+    object: "chat.completion",
+    created: 0,
+    model,
+    choices: [{ index: 0, message, finish_reason: isToolTurn(turn) ? "tool_calls" : "stop" }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
+// Past the end of the script the model must stop, or opencode would loop forever.
+const EXHAUSTED: TextTurn = { text: "Script exhausted." };
+
+export function createStubProvider(scriptPath: string, port: number): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+    port,
+    idleTimeout: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+
+      if (url.pathname === "/health") return new Response("ok");
+
+      if (url.pathname.endsWith("/models")) {
+        return Response.json({ object: "list", data: [{ id: "stub-model", object: "model" }] });
+      }
+
+      if (!url.pathname.endsWith("/chat/completions")) {
+        return new Response("not found", { status: 404 });
+      }
+
+      const body: unknown = await request.json();
+      if (!isChatRequest(body)) return new Response("bad request", { status: 400 });
+
+      const script = await loadScript(scriptPath);
+      const index = assistantTurnsSoFar(body);
+      const turn = script[index] ?? EXHAUSTED;
+      const model = body.model ?? "stub-model";
+      const args = isToolTurn(turn) ? resolveArgs(turn.args, body.messages ?? []) : {};
+
+      console.log(`[stub] turn ${index}: ${isToolTurn(turn) ? `tool ${turn.tool} ${JSON.stringify(args)}` : "text"}`);
+
+      if (body.stream === false) return Response.json(completionBody(model, turn, args));
+
+      return new Response(streamTurn(model, turn, args), { headers: SSE_HEADERS });
+    },
+  });
+}
+
+if (import.meta.main) {
+  const scriptPath = process.env.STUB_SCRIPT;
+  if (!scriptPath) throw new Error("STUB_SCRIPT must point at a script JSON file");
+
+  const port = Number(process.env.STUB_PORT ?? DEFAULT_PORT);
+  createStubProvider(scriptPath, port);
+  console.log(`[stub] listening on ${port}, replaying ${scriptPath}`);
+}

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run clean && bun run check && bun run build",
-    "test": "bun test",
-    "test:watch": "bun test --watch",
+    "test": "bun test tests",
+    "test:watch": "bun test tests --watch",
     "format": "biome format --write .",
     "lint": "biome lint . && eslint .",
     "lint:biome": "biome lint .",
     "lint:eslint": "eslint .",
-    "check": "biome check . && eslint . && bun run typecheck && bun test"
+    "check": "biome check . && eslint . && bun run typecheck && bun test tests",
+    "test:e2e": "docker build -f e2e/Dockerfile -t octto-e2e . && docker run --rm octto-e2e"
   },
   "keywords": [
     "opencode",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -8,5 +8,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "e2e"]
 }


### PR DESCRIPTION
Builds the end-to-end setup you asked for: opencode + octto running in a container, real Chromium under Xvfb, driven so we can verify the whole stack and test future octto changes.

**Based on #48**, so the diff stays focused. That branch supplies the `allowOther` fix the first spec asserts on.

```bash
bun run test:e2e
```

Green in ~13s: `1 pass, 0 fail, 4 expect() calls`.

## What is real

The opencode runtime, the octto plugin loaded the way users load it, Chromium reached through octto's own `xdg-open` call, the session HTTP server, and the websocket round-trip. Only the **model** is faked: a scripted OpenAI-compatible provider replays fixed tool calls, so runs are deterministic, offline and free.

The first spec asserts what the agent actually receives:

```json
"tool":"get_next_answer", "output":"## Answer Received … {\"selected\": \"other\", \"other\": \"SQLite with Litestream\"}"
```

That value only exists if the plugin loaded, the browser opened, the UI honoured `allowOther`, the user typed into it and the websocket carried it back.

**The harness demonstrably catches real bugs.** On `main` it fails with `Timed out waiting in page for other freetext field`; with #48's fix merged it passes. That is the regression #48 fixes, caught end to end.

## Findings worth keeping

Each of these cost a debugging cycle and is documented in `e2e/README.md`:

- Local plugins load by **absolute path in the `plugin` array**. The documented `.opencode/plugins/` directory did not load them.
- opencode has no config-dir env var; isolation is via `HOME`. Since each spec gets its own `HOME`, the default-browser association must be system-wide (`/etc/xdg/mimeapps.list`) or `xdg-open` has no handler at all.
- `xdg-open` must launch Chromium with the **same** `--user-data-dir` as the CDP instance, and with `--no-sandbox`, or it silently starts a second, unobservable browser.
- `playwright-core` hangs on the CDP websocket handshake under Bun; a plain `WebSocket` works, so the suite talks raw CDP and carries no browser-driver dependency.
- `bun test tests` treats its argument as a substring filter, so it also matched `e2e/tests/`. Specs moved to `e2e/specs/` to stay out of the normal gate. `bun run check` is unchanged in scope: 235 pass.

## Limits

This tier **cannot** catch prompt-adherence bugs, where the model simply fails to make the next call. Issue #7's follow-up bug is exactly that class. The live-model tier is still to come, gated on a secret and skipped when absent.

Plannotator is not wired in yet: the octto loop landed first, as agreed. The three investigation agents have since established exactly why the octto+plannotator combination misbehaves, which is a separate change.