### PR TITLE
fix: stop leaking octto's agent objects into resolved config

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -143,7 +143,12 @@ export async function loadCustomConfig(
 ): Promise<CustomConfig> {
   const config = await load(configDir);
 
+  // Copy each agent, not just the outer record: callers prefix prompts in place,
+  // and a shallow copy would mutate the shared built-in definitions.
   const mergedAgents = { ...agents };
+  for (const name of Object.values(AGENTS)) {
+    mergedAgents[name] = { ...mergedAgents[name] };
+  }
 
   // Apply top-level model to all agents first
   if (config?.model) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin";
+import type { AgentConfig } from "@opencode-ai/sdk";
 
 import { AGENTS, agents } from "@/agents";
 import { loadCustomConfig } from "@/config";
@@ -6,6 +7,26 @@ import { createFragmentInjector, getAgentSystemPromptPrefix, warnUnknownAgents }
 import { createSessionStore } from "@/session";
 import type { OcttoTool } from "@/tools";
 import { createOcttoTools, outputText } from "@/tools";
+
+/**
+ * Layers octto's agents onto whatever the host resolved so far.
+ *
+ * Merges per agent rather than replacing the entry, so keys other plugins set
+ * (permissions, for example) survive. Each entry is a fresh object: handing out
+ * our own would let another plugin's in-place mutation reach octto's state and
+ * persist across config resolutions.
+ */
+type ResolvedAgents = Record<string, AgentConfig | undefined>;
+
+function mergeAgents(existing: ResolvedAgents | undefined, ours: Record<string, AgentConfig>): ResolvedAgents {
+  const merged: ResolvedAgents = { ...existing };
+
+  for (const [name, agent] of Object.entries(ours)) {
+    merged[name] = { ...merged[name], ...agent };
+  }
+
+  return merged;
+}
 
 function wrapWithTracking(tool: OcttoTool, tracked: Map<string, Set<string>>): void {
   const originalExecute = tool.execute;
@@ -46,7 +67,7 @@ const Octto: Plugin = async ({ client, directory }) => {
     tool: tools,
 
     config: async (config) => {
-      config.agent = { ...config.agent, ...customConfig.agents };
+      config.agent = mergeAgents(config.agent, customConfig.agents);
     },
 
     event: async ({ event }) => {

--- a/tests/agent-config-merge.test.ts
+++ b/tests/agent-config-merge.test.ts
@@ -1,0 +1,75 @@
+// tests/agent-config-merge.test.ts
+import { describe, expect, it } from "bun:test";
+
+import type { PluginInput } from "@opencode-ai/plugin";
+
+function createMockContext(): PluginInput {
+  return {
+    client: {} as never,
+    project: {} as never,
+    directory: "/test",
+    worktree: "/test",
+    serverUrl: new URL("http://localhost:3000"),
+    $: {} as never,
+  };
+}
+
+interface AgentShape {
+  model?: string;
+  permission?: Record<string, string>;
+}
+
+async function applyConfig(agent: Record<string, AgentShape>): Promise<Record<string, AgentShape>> {
+  const { default: plugin } = await import("../src");
+  const hooks = await plugin(createMockContext());
+  const config = { agent };
+  await hooks.config?.(config as never);
+  return config.agent;
+}
+
+describe("agent config merge", () => {
+  it("should keep keys another plugin set on the same agent", async () => {
+    const merged = await applyConfig({ octto: { permission: { submit_plan: "allow" } } });
+
+    // octto owns model/prompt; it must not wipe unrelated keys it never sets.
+    expect(merged.octto?.permission).toEqual({ submit_plan: "allow" });
+    expect(merged.octto?.model).toBeDefined();
+  });
+
+  it("should not leak its internal agent objects into the resolved config", async () => {
+    const first = await applyConfig({});
+    const octto = first.octto;
+    expect(octto).toBeDefined();
+
+    // Another plugin mutating the resolved config must not reach octto's own state.
+    if (octto) octto.permission = { submit_plan: "deny" };
+
+    const second = await applyConfig({});
+    expect(second.octto?.permission).toBeUndefined();
+  });
+
+  it("should hand out a distinct agent object on every resolution", async () => {
+    const first = await applyConfig({});
+    const second = await applyConfig({});
+
+    expect(first.octto).not.toBe(second.octto);
+  });
+
+  it("should not accumulate injected prompt fragments across plugin instantiations", async () => {
+    const { default: plugin } = await import("../src");
+    const marker = "<user-instructions>";
+
+    const countIn = async (): Promise<number> => {
+      const hooks = await plugin(createMockContext());
+      const config: { agent: Record<string, { prompt?: string }> } = { agent: {} };
+      await hooks.config?.(config as never);
+      return config.agent.octto?.prompt?.split(marker).length ?? 0;
+    };
+
+    const first = await countIn();
+    const second = await countIn();
+
+    // Re-instantiating must re-prefix a clean prompt, not stack onto the last one.
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
Two shallow copies let octto's own state be mutated from outside. Both were found empirically while investigating #13, and both are real independent of plannotator.

## 1. Fragment prompts accumulated across resolutions

`loadCustomConfig` copied only the outer record:

```ts
const mergedAgents = { ...agents };   // entries still point at the built-in definitions
```

`src/index.ts` then prefixes fragment instructions onto `customConfig.agents[name].prompt` **in place**, mutating the shared module-level agent. Re-instantiating the plugin re-prefixed an already-prefixed prompt. Observed in test output, five stacked copies of the same block:

```
<user-instructions>…</user-instructions>
<user-instructions>…</user-instructions>
<user-instructions>…</user-instructions>   (x5)
```

Every agent gets its own copy now.

## 2. The config hook handed out live references

```ts
config.agent = { ...config.agent, ...customConfig.agents };
```

Two problems. It replaced each agent entry **wholesale**, discarding keys another plugin had set on that same agent. And the value stored was octto's own object, so a plugin mutating `config.agent.octto` reached octto's stored config, and the mutation **survived every later resolution**.

That is not hypothetical. With plannotator installed, it writes `permission.submit_plan = "deny"` onto primary agents; once it does, the deny is baked into octto's module-level state for the life of the process. Merging per agent into a fresh object fixes both.

## Scope

This is the object-lifetime bug only. It does **not** change which side wins a conflict: octto's explicit values still take precedence, consistent with closing #8. It does mean keys octto never sets now survive instead of being dropped.

It is also **not** a fix for #13. The plannotator interaction has three independent gates, and the decisive one is a hard-coded guard inside plannotator's own `submit_plan.execute()`. Users need `planningAgents: ["plan", "octto"]` or `workflow: "user-managed"`. This just stops octto corrupting its own state as a side effect.

## Verification

Four new tests, written failing first. Mutation-checked: reverting the loader fix alone fails the accumulation test, leaving the other three green.

`bun run check`: 234 pass, 0 fail. `bun run build` clean.