### PR TITLE
fix: session teardown hang, brainstorm livelock, and unauthenticated session server

### DIFF
--- a/src/session/server.ts
+++ b/src/session/server.ts
@@ -11,12 +11,13 @@ const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
 const HTTP_FORBIDDEN = 403;
 const LOOPBACK_HOST = "127.0.0.1";
+const LOOPBACK_NAME = "localhost";
 
 interface WsData {
   sessionId: string;
 }
 
-/** A browser sends Origin on upgrade; a matching Host means the page came from this server. */
+/** A browser sends Origin on upgrade; a matching loopback Host means the page came from this server. */
 function isSameOrigin(req: Request): boolean {
   const origin = req.headers.get("origin");
   if (!origin) return true;
@@ -25,6 +26,11 @@ function isSameOrigin(req: Request): boolean {
   if (!host) return false;
 
   try {
+    // Rebinding a domain to 127.0.0.1 makes Origin and Host match each other, so
+    // requiring a loopback Host is what actually pins the page to this server.
+    const { hostname } = new URL(`http://${host}`);
+    if (hostname !== LOOPBACK_HOST && hostname !== LOOPBACK_NAME) return false;
+
     return new URL(origin).host === host;
   } catch (_error: unknown) {
     return false;

--- a/src/session/server.ts
+++ b/src/session/server.ts
@@ -9,10 +9,26 @@ import { WsClientMessageSchema } from "./types";
 
 const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
+const HTTP_FORBIDDEN = 403;
 const LOOPBACK_HOST = "127.0.0.1";
 
 interface WsData {
   sessionId: string;
+}
+
+/** A browser sends Origin on upgrade; a matching Host means the page came from this server. */
+function isSameOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return true;
+
+  const host = req.headers.get("host");
+  if (!host) return false;
+
+  try {
+    return new URL(origin).host === host;
+  } catch (_error: unknown) {
+    return false;
+  }
 }
 
 function handleFetch(
@@ -24,6 +40,10 @@ function handleFetch(
   const url = new URL(req.url);
 
   if (url.pathname === "/ws") {
+    if (!isSameOrigin(req)) {
+      return new Response("Forbidden", { status: HTTP_FORBIDDEN });
+    }
+
     const success = server.upgrade(req, {
       data: { sessionId },
     });

--- a/src/session/server.ts
+++ b/src/session/server.ts
@@ -9,6 +9,7 @@ import { WsClientMessageSchema } from "./types";
 
 const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
+const LOOPBACK_HOST = "127.0.0.1";
 
 interface WsData {
   sessionId: string;
@@ -94,6 +95,7 @@ export async function createServer(
   const htmlBundle = getHtmlBundle();
 
   const server = Bun.serve<WsData>({
+    hostname: LOOPBACK_HOST,
     port: configuredPort ?? 0,
     fetch: (req, srv) => handleFetch(req, srv, sessionId, htmlBundle),
     websocket: {

--- a/src/session/sessions.ts
+++ b/src/session/sessions.ts
@@ -129,7 +129,8 @@ async function endSession(state: StoreState, sessionId: string): Promise<EndSess
   }
 
   if (session.server) {
-    await session.server.stop();
+    // Without closeActiveConnections the promise never settles while the UI socket is attached.
+    await session.server.stop(true);
   }
 
   for (const questionId of session.questions.keys()) {

--- a/src/tools/brainstorm.ts
+++ b/src/tools/brainstorm.ts
@@ -34,6 +34,7 @@ const COLLECTION_STOPS = {
   COMPLETE: "complete",
   NO_ANSWER_WITHIN_TIMEOUT: "no_answer_within_timeout",
   ITERATION_CAP: "iteration_cap",
+  STALLED: "stalled",
 } as const;
 
 type CollectionStop = (typeof COLLECTION_STOPS)[keyof typeof COLLECTION_STOPS];
@@ -94,9 +95,14 @@ async function processOneAnswer(
   sessionId: string,
   browserSessionId: string,
   client: OpencodeClient,
-): Promise<"continue" | "break"> {
+): Promise<"continue" | "break" | "stalled"> {
   if (!answer.completed) {
-    if (answer.status === STATUSES.NONE_PENDING) await flushPending(pending);
+    if (answer.status === STATUSES.NONE_PENDING) {
+      // flushPending empties the array, so read it first.
+      const mayStillPushQuestions = pending.length > 0;
+      await flushPending(pending);
+      return mayStillPushQuestions ? "continue" : "stalled";
+    }
     return answer.status === STATUSES.TIMEOUT ? "break" : "continue";
   }
 
@@ -140,6 +146,10 @@ async function collectAnswers(
     const action = await processOneAnswer(answer, pending, stateStore, sessions, sessionId, browserSessionId, client);
     if (action === "break") {
       stoppedBecause = COLLECTION_STOPS.NO_ANSWER_WITHIN_TIMEOUT;
+      break;
+    }
+    if (action === "stalled") {
+      stoppedBecause = COLLECTION_STOPS.STALLED;
       break;
     }
   }
@@ -207,18 +217,31 @@ async function waitForReviewApproval(sessions: SessionStore, browserSessionId: s
 
 function formatInProgressResult(state: BrainstormState, stoppedBecause: CollectionStop): string {
   const branches = state.branch_order.map((id) => formatBranchStatus(state.branches[id])).join("\n");
-  const reason =
-    stoppedBecause === COLLECTION_STOPS.ITERATION_CAP
-      ? `Collected ${MAX_ITERATIONS} answers in one call, the per-call limit.`
-      : "No answer arrived within the wait window; the user is still thinking.";
   return `<brainstorm_in_progress>
   <request>${state.request}</request>
   <branches>
 ${branches}
   </branches>
-  <reason>${reason}</reason>
-  <next_action>The brainstorm is NOT finished and no branch was abandoned. Call await_brainstorm_complete again immediately with the same ids. Do not summarize, do not write the design document, and do not ask the user anything.</next_action>
+  <reason>${describeStop(stoppedBecause)}</reason>
+  <next_action>${describeNextAction(stoppedBecause)}</next_action>
 </brainstorm_in_progress>`;
+}
+
+function describeStop(stoppedBecause: CollectionStop): string {
+  if (stoppedBecause === COLLECTION_STOPS.ITERATION_CAP) {
+    return `Reached the ${MAX_ITERATIONS} iteration limit for one call.`;
+  }
+  if (stoppedBecause === COLLECTION_STOPS.STALLED) {
+    return "No question is pending and no answer is being processed, so the session cannot progress on its own.";
+  }
+  return "No answer arrived within the wait window; the user is still thinking.";
+}
+
+function describeNextAction(stoppedBecause: CollectionStop): string {
+  if (stoppedBecause === COLLECTION_STOPS.STALLED) {
+    return "The session cannot progress on its own. Call end_brainstorm to close it out with the findings collected so far. Do not call await_brainstorm_complete again.";
+  }
+  return "The brainstorm is NOT finished and no branch was abandoned. Call await_brainstorm_complete again immediately with the same ids. Do not summarize, do not write the design document, and do not ask the user anything.";
 }
 
 function formatSkippedReviewResult(state: BrainstormState): string {

--- a/src/tools/processor.ts
+++ b/src/tools/processor.ts
@@ -148,7 +148,12 @@ async function handleProbeResult(
     return;
   }
 
-  if (!probe.question) return;
+  if (!probe.question) {
+    // Returning here would leave the branch exploring with nothing pending, which
+    // spins await_brainstorm_complete forever.
+    await stateStore.completeBranch(sessionId, branchId, probe.finding || "Probe returned no question");
+    return;
+  }
 
   const rawQuestion = probe.question.config.question;
   const rawContext = probe.question.config.context;

--- a/src/tools/processor.ts
+++ b/src/tools/processor.ts
@@ -79,7 +79,15 @@ export function parseProbeResponse(parts: { type: string; [key: string]: unknown
     return { done: true, finding: "Could not parse probe response" };
   }
 
-  const parsed = v.safeParse(ProbeResultSchema, JSON.parse(jsonMatch[0]));
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(jsonMatch[0]);
+  } catch (_error: unknown) {
+    // The match is greedy, so prose braces before the JSON produce invalid input.
+    return { done: true, finding: "Could not parse probe response" };
+  }
+
+  const parsed = v.safeParse(ProbeResultSchema, candidate);
   if (!parsed.success) {
     return { done: true, finding: "Could not validate probe response" };
   }

--- a/src/ui/bundle.ts
+++ b/src/ui/bundle.ts
@@ -734,6 +734,7 @@ export function getHtmlBundle(): string {
   <script>
     const wsUrl = 'ws://' + window.location.host + '/ws';
     let ws = null;
+    let ended = false;
     let questions = [];
     let expandedAnswers = new Set();
     
@@ -754,12 +755,15 @@ export function getHtmlBundle(): string {
           questions = questions.filter(q => q.id !== msg.id);
           render();
         } else if (msg.type === 'end') {
+          ended = true;
           document.getElementById('root').innerHTML = 
             '<div class="session-ended"><h1>Session Ended</h1><p>You can close this window.</p></div>';
+          ws.close();
         }
       };
       
       ws.onclose = () => {
+        if (ended) return;
         setTimeout(connect, 2000);
       };
     }

--- a/tests/integration/multi-agent.test.ts
+++ b/tests/integration/multi-agent.test.ts
@@ -80,6 +80,20 @@ describe("Multi-Agent Integration", () => {
       expect(result.finding).toBe("Could not validate probe response");
     });
 
+    it("should not throw when prose braces precede the probe JSON", () => {
+      const parts = [
+        {
+          type: "text",
+          text: 'Thinking about {the scope} now.\n{"done": false, "question": {"type": "pick_one", "config": {}}}',
+        },
+      ];
+
+      const result = parseProbeResponse(parts);
+
+      expect(result.done).toBe(true);
+      expect(result.finding).toBe("Could not parse probe response");
+    });
+
     it("should extract JSON embedded in surrounding text", () => {
       const parts = [
         {

--- a/tests/session/server.test.ts
+++ b/tests/session/server.test.ts
@@ -135,4 +135,10 @@ describe("Server WebSocket error handling", () => {
 
     expect(outcome).toBe("resolved");
   });
+
+  it("should bind to loopback only", () => {
+    const session = sessions.getSession(sessionId);
+
+    expect(session?.server?.hostname).toBe("127.0.0.1");
+  });
 });

--- a/tests/session/server.test.ts
+++ b/tests/session/server.test.ts
@@ -121,4 +121,18 @@ describe("Server WebSocket error handling", () => {
     expect(session).toBeDefined();
     expect(session!.port).toBeGreaterThan(0);
   });
+
+  it("should resolve endSession even while a browser socket is still open", async () => {
+    const ws = new WebSocket(`${url.replace("http", "ws")}/ws`);
+    await new Promise<void>((resolve) => {
+      ws.onopen = () => resolve();
+    });
+
+    const outcome = await Promise.race([
+      sessions.endSession(sessionId).then(() => "resolved" as const),
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 2000)),
+    ]);
+
+    expect(outcome).toBe("resolved");
+  });
 });

--- a/tests/session/server.test.ts
+++ b/tests/session/server.test.ts
@@ -166,4 +166,50 @@ describe("Server WebSocket error handling", () => {
     expect(opened).toBe(true);
     ws.close();
   });
+
+  it("should reject a websocket upgrade when the host header is not loopback", async () => {
+    // DNS rebinding points an attacker's domain at 127.0.0.1, so the browser sends
+    // that domain as both Host and Origin and they match each other.
+    const port = Number(new URL(url).port);
+    const status = await rawUpgradeStatus(port, `evil.example:${port}`, `http://evil.example:${port}`);
+
+    expect(status).toBe(403);
+  });
 });
+
+/** fetch() forbids setting Host, so drive the upgrade over a raw socket. */
+async function rawUpgradeStatus(port: number, host: string, origin: string): Promise<number> {
+  const request = [
+    "GET /ws HTTP/1.1",
+    `Host: ${host}`,
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    "Sec-WebSocket-Version: 13",
+    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+    `Origin: ${origin}`,
+  ].join("\r\n");
+
+  let received = "";
+  const socket = await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      data: (_socket, chunk) => {
+        received += chunk.toString();
+      },
+    },
+  });
+  socket.write(`${request}\r\n\r\n`);
+
+  await waitUntil(() => received.includes("\r\n"));
+  socket.end();
+
+  return Number(received.split(" ")[1]);
+}
+
+async function waitUntil(condition: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (!condition() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/tests/session/server.test.ts
+++ b/tests/session/server.test.ts
@@ -141,4 +141,29 @@ describe("Server WebSocket error handling", () => {
 
     expect(session?.server?.hostname).toBe("127.0.0.1");
   });
+
+  it("should reject a websocket upgrade from a foreign origin", async () => {
+    const response = await fetch(`${url}/ws`, {
+      headers: {
+        Upgrade: "websocket",
+        Connection: "Upgrade",
+        "Sec-WebSocket-Version": "13",
+        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+        Origin: "http://evil.example",
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should still accept a websocket with no origin header", async () => {
+    const ws = new WebSocket(`${url.replace("http", "ws")}/ws`);
+    const opened = await new Promise<boolean>((resolve) => {
+      ws.onopen = () => resolve(true);
+      ws.onerror = () => resolve(false);
+    });
+
+    expect(opened).toBe(true);
+    ws.close();
+  });
 });

--- a/tests/tools/brainstorm.test.ts
+++ b/tests/tools/brainstorm.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createSessionStore } from "../../src/session/sessions";
+import { createStateStore } from "../../src/state/store";
 import { createBrainstormTools } from "../../src/tools/brainstorm";
 import { outputText } from "../../src/tools/output";
 
@@ -70,6 +71,27 @@ describe("Brainstorm Tools", () => {
       const nextAction = result.slice(result.indexOf("<next_action>"), result.indexOf("</next_action>"));
       expect(nextAction).toContain("await_brainstorm_complete");
       expect(nextAction).not.toContain("Call get_next_answer");
+    });
+  });
+
+  describe("await_brainstorm_complete", () => {
+    it("should stop collecting instead of spinning when nothing is pending", async () => {
+      const stateStore = createStateStore(tempDir);
+      await stateStore.createSession("ses_stalled", "req", [{ id: "b1", scope: "scope one" }]);
+      const browser = await sessions.startSession({});
+
+      const startedAt = performance.now();
+      const output = outputText(
+        await tools.await_brainstorm_complete.execute(
+          { session_id: "ses_stalled", browser_session_id: browser.session_id },
+          {} as any,
+        ),
+      );
+      const elapsed = performance.now() - startedAt;
+
+      expect(output).not.toContain("Collected 50 answers");
+      expect(output).toContain("end_brainstorm");
+      expect(elapsed).toBeLessThan(1000);
     });
   });
 });

--- a/tests/tools/brainstorm.test.ts
+++ b/tests/tools/brainstorm.test.ts
@@ -80,18 +80,18 @@ describe("Brainstorm Tools", () => {
       await stateStore.createSession("ses_stalled", "req", [{ id: "b1", scope: "scope one" }]);
       const browser = await sessions.startSession({});
 
-      const startedAt = performance.now();
       const output = outputText(
         await tools.await_brainstorm_complete.execute(
           { session_id: "ses_stalled", browser_session_id: browser.session_id },
           {} as any,
         ),
       );
-      const elapsed = performance.now() - startedAt;
 
+      // The stall is observable in the message, not the clock: the old loop spun
+      // through all 50 iterations just as fast and then told the agent to retry.
       expect(output).not.toContain("Collected 50 answers");
+      expect(output).toContain("cannot progress on its own");
       expect(output).toContain("end_brainstorm");
-      expect(elapsed).toBeLessThan(1000);
     });
   });
 });

--- a/tests/tools/processor.test.ts
+++ b/tests/tools/processor.test.ts
@@ -101,6 +101,36 @@ describe("processAnswer", () => {
     expect(updated?.branches.b1.questions.length).toBe(2);
   });
 
+  it("should complete the branch when the probe wants to continue but sends no question", async () => {
+    await stateStore.createSession("ses_test", "test request", [{ id: "b1", scope: "scope1" }]);
+    const browserSession = await sessions.startSession({ title: "Test" });
+    await stateStore.setBrowserSessionId("ses_test", browserSession.session_id);
+
+    const { question_id } = sessions.pushQuestion(browserSession.session_id, "confirm", { question: "Test?" });
+    await stateStore.addQuestionToBranch("ses_test", "b1", {
+      id: question_id,
+      type: "confirm",
+      text: "Test?",
+      config: { question: "Test?" },
+    });
+
+    const client = createMockClient({ done: false });
+
+    await processAnswer(
+      stateStore,
+      sessions,
+      "ses_test",
+      browserSession.session_id,
+      question_id,
+      { choice: "yes" },
+      client,
+    );
+
+    const updated = await stateStore.getSession("ses_test");
+    expect(updated?.branches.b1.status).toBe("done");
+    expect(updated?.branches.b1.finding).toBe("Probe returned no question");
+  });
+
   it("should silently return when session not found", async () => {
     const client = createMockClient({ done: true });
     await processAnswer(


### PR DESCRIPTION
Fixes three defects that made octto hang, loop forever, or accept connections it should refuse. Each was reproduced before being fixed, and each reproduction was re-run against the final code.

## 1. `end_brainstorm` hung until the user closed the tab

`endSession` awaited `server.stop()` without `closeActiveConnections`, and that promise does not settle while a websocket is still attached. The UI's `end` handler only swapped the DOM, never closed its socket, and `onclose` reconnected every 2s regardless.

Every caller hung with it: `end_brainstorm`, `end_session`, and the `session.deleted` handler. Measured: still pending after 3000ms with a socket open, 0ms after the fix.

The UI now closes its socket on `end` and skips the reconnect, which also stops a stale tab latching onto the next session's server when `OCTTO_PORT` is pinned.

## 2. `await_brainstorm_complete` could loop forever

A branch could end up `EXPLORING` with no pending question. `getNextAnswer` then returns `none_pending` immediately rather than blocking, so the collection loop burned all 50 iterations in milliseconds and emitted a result claiming `Collected 50 answers in one call` (zero had arrived) that told the agent to call again immediately.

Two reproduced routes in, both closed:

- `ProbeResultSchema` makes `question` optional, so `{"done": false}` with no question validated and the handler returned silently, stranding the branch. It now completes the branch.
- `JSON.parse` sat outside any try/catch and the extraction regex is greedy, so probe output like `Thinking about {the scope} now.\n{"done": false}` threw a `SyntaxError` that was swallowed upstream. It now returns the parse fallback.

The loop itself also bails out now: `none_pending` with no in-flight answer processing means nothing can ever arrive, so it stops and tells the agent to call `end_brainstorm` instead of looping. The `iteration_cap` message no longer claims answers it did not collect.

## 3. The session server was reachable from the local network with no auth

`Bun.serve` was called with no `hostname`, so it bound the wildcard address. Verified with `lsof` (`TCP *:PORT`) and by fetching the full UI over the LAN IP. The `/ws` upgrade had no origin check and no token, so any socket reaching it was bound to the live session.

The server now binds `127.0.0.1`, and upgrades must carry a same-origin, loopback Host.

Websockets are not covered by same-origin policy, so this was reachable from an ordinary browsing session, not just the LAN. An origin check alone is not enough: DNS rebinding lets an attacker control Origin and Host together so they match each other, which is why Host must also be loopback.

```
attacker Origin, real Host          -> 403
Origin: null                        -> 403
REBIND: Host and Origin both evil   -> 403   (was 101 Switching Protocols)
no Origin (tests, CLI)              -> 101   (unchanged, by design)
```

Clients that send no Origin are still accepted so the existing tests and any non-browser client keep working. Remote attackers are stopped at the socket by the loopback bind.

## Verification

- `bun run check`: 248 pass, 0 fail (240 before this branch). Biome, ESLint and tsc clean.
- `bun run build`: succeeds.
- `bun run test:e2e`: 1 pass, 0 fail, with real opencode and real Chromium. This is what confirms the loopback bind did not break the Docker harness, whose browser reaches the UI over `http://localhost:7777`.

Each new test was checked to genuinely fail when its fix is reverted.

## Known gaps

- The three lines of reconnect-guard JS in `bundle.ts` have no automated coverage; neither e2e spec ends a session. What is verified is that the `end` frame reaches the client before the socket is torn down, so fixes 1 and 2 compose.
- `parseProbeResponse` still matches greedily, so a probe emitting prose with braces now loses what it actually said rather than crashing. Recovering it is a behaviour change, left out deliberately.
- `startSession` returns `http://localhost:${port}` while the socket binds `127.0.0.1`. Works everywhere tested, but the two are no longer the same string.
